### PR TITLE
feat: Add power and voltage to Deye TOU programs

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_sg04lp3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_sg04lp3.yaml
@@ -598,6 +598,195 @@ parameters:
           max: 2359
         icon: mdi:sun-clock
 
+      # Program x power is the max discharge power during the time slot
+      #
+      - name: Program 1 Power
+        update_interval: 300
+        class: "power"
+        state_class: measurement
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x009A]
+        configurable:
+        range:
+          min: 0000
+          max: 12000
+        icon: mdi:sun-clock
+
+      - name: Program 2 Power
+        update_interval: 300
+        class: "power"
+        state_class: measurement
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x009B]
+        configurable:
+        range:
+          min: 0000
+          max: 12000
+        icon: mdi:sun-clock
+
+      - name: Program 3 Power
+        update_interval: 300
+        class: "power"
+        state_class: measurement
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x009C]
+        configurable:
+        range:
+          min: 0000
+          max: 12000
+
+        icon: mdi:sun-clock
+      - name: Program 4 Power
+        update_interval: 300
+        class: "power"
+        state_class: measurement
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x009D]
+        configurable:
+        range:
+          min: 0000
+          max: 12000
+        icon: mdi:sun-clock
+
+      - name: Program 5 Power
+        update_interval: 300
+        class: "power"
+        state_class: measurement
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x009E]
+        configurable:
+        range:
+          min: 0000
+          max: 12000
+        icon: mdi:sun-clock
+
+      - name: Program 6 Power
+        update_interval: 300
+        class: "power"
+        state_class: measurement
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x009F]
+        configurable:
+        range:
+          min: 0000
+          max: 12000
+        icon: mdi:sun-clock
+
+      # Program x voltage is the voltage at/until the program operation is valid.
+      - name: Program 1 Voltage
+        update_interval: 300
+        class: "voltage"
+        state_class: measurement
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x00A0]
+        configurable:
+          min: 38
+          max: 61
+          step: 0.1
+        range:
+          min: 3800
+          max: 6100
+        icon: mdi:sun-clock
+
+      - name: Program 2 Voltage
+        update_interval: 300
+        class: "voltage"
+        state_class: measurement
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x00A1]
+        configurable:
+          min: 38
+          max: 61
+          step: 0.1
+        range:
+          min: 3800
+          max: 6100
+        icon: mdi:sun-clock
+
+      - name: Program 3 Voltage
+        update_interval: 300
+        class: "voltage"
+        state_class: measurement
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x00A2]
+        configurable:
+          min: 38
+          max: 61
+          step: 0.1
+        range:
+          min: 3800
+          max: 6100
+        icon: mdi:sun-clock
+
+      - name: Program 4 Voltage
+        update_interval: 300
+        class: "voltage"
+        state_class: measurement
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x00A3]
+        configurable:
+          min: 38
+          max: 61
+          step: 0.1
+        range:
+          min: 3800
+          max: 6100
+        icon: mdi:sun-clock
+
+      - name: Program 5 Voltage
+        update_interval: 300
+        class: "voltage"
+        state_class: measurement
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x00A4]
+        configurable:
+          min: 38
+          max: 61
+          step: 0.1
+        range:
+          min: 3800
+          max: 6100
+        icon: mdi:sun-clock
+
+      - name: Program 6 Voltage
+        update_interval: 300
+        class: "voltage"
+        state_class: measurement
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x00A5]
+        configurable:
+          min: 38
+          max: 61
+          step: 0.1
+        range:
+          min: 3800
+          max: 6100
+        icon: mdi:sun-clock
+
       - name: Program 1 SOC
         update_interval: 300
         class: ""


### PR DESCRIPTION
Added definitions for maximum allowed discharge power and voltage condition of time-of-use (TOU) to deye_sg04lp3.yaml inverter definition.

Power values for 6 programs are available from registers 154 - 159 and voltages from registers 160 - 165.

~Added also a definition for a switch that tells if TOU programs are in use (register 146).~

The SOC values for programs are already included. SOC or voltage is used based on battery control mode (inverter_battery_operation_mode, voltage or capacity).