### PR TITLE
bugfix: Revert battery radiator temperature name

### DIFF
--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
@@ -377,7 +377,7 @@ parameters:
           min: 10
           max: 95
 
-      - name: "Battery Temperature"
+      - name: "Battery Heatsink Temperature"
         update_interval: 30
         class: "temperature"
         state_class: "measurement"


### PR DESCRIPTION
The battery has 2 different temperatures: battery and radiator