### PR TITLE
bugfix: revert name on KSTAR Battery type

### DIFF
--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
@@ -299,7 +299,7 @@ parameters:
 
   - group: Battery
     items:
-      - name: "Battery Control Mode"
+      - name: "Battery Type"
         update_interval: 300
         class: "enum"
         state_class: ""


### PR DESCRIPTION
This register holds the battery type according to the documentation, not the control mode.

It was changed some time ago when renaming a bunch of other sensors.