### PR TITLE
ZCS Azzurro icons update

### DIFF
--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -174,7 +174,7 @@ parameters:
         scale: 1
         rule: 1
         registers: [0x060A]
-        icon: "mdi:battery-check-outline"
+        icon: "mdi:battery-sync-outline"
 
       - name: "Battery Power"
         realtime:

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -154,7 +154,7 @@ parameters:
         scale: 0.1
         rule: 1
         registers: [0x0697, 0x0696]
-        icon: "mdi:battery-clock"
+        icon: "mdi:battery-high"
 
       - name: "Total Battery Discharge"
         alt: "Battery Discharge Total"
@@ -165,7 +165,7 @@ parameters:
         scale: 0.1
         rule: 1
         registers: [0x069B, 0x069A]
-        icon: "mdi:battery-clock-outline"
+        icon: "mdi:battery-medium"
 
       - name: "Battery Cycles"
         class: ""
@@ -196,7 +196,7 @@ parameters:
         scale: 0.01
         rule: 3
         registers: [0x0695, 0x0694]
-        icon: "mdi:home-lightning-bolt"
+        icon: "mdi:battery-high"
 
       - name: "Today Battery Discharge"
         alt: Battery Discharge Today
@@ -208,7 +208,7 @@ parameters:
         scale: 0.01
         rule: 3
         registers: [0x0699, 0x0698]
-        icon: "mdi:home-lightning-bolt"
+        icon: "mdi:battery-medium"
 
   - group: Grid
     items:
@@ -282,7 +282,7 @@ parameters:
         scale: 0.01
         rule: 3
         registers: [0x068D, 0x068C]
-        icon: "mdi:home-lightning-bolt"
+        icon: "mdi:home-import-outline"
 
       - name: "Total Energy Import"
         alt: "Energy Purchase Total"
@@ -293,7 +293,7 @@ parameters:
         scale: 0.1
         rule: 3
         registers: [0x068F, 0x068E]
-        icon: "mdi:home-lightning-bolt"
+        icon: "mdi:home-import-outline"
 
       - name: "Today Energy Export"
         alt: Energy Selling Today
@@ -305,7 +305,7 @@ parameters:
         scale: 0.01
         rule: 3
         registers: [0x0691, 0x0690]
-        icon: "mdi:home-lightning-bolt"
+        icon: "mdi:home-export-outline"
 
       - name: "Total Energy Export"
         alt: "Energy Selling Total"
@@ -316,7 +316,7 @@ parameters:
         scale: 0.1
         rule: 3
         registers: [0x0693, 0x0692]
-        icon: "mdi:home-lightning-bolt"
+        icon: "mdi:home-export-outline"
 
   - group: Device
     items:

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -143,7 +143,7 @@ parameters:
         #se non funziona cambia questo in 2
         rule: 1
         registers: [0x0607]
-        icon: "mdi:battery-heart-outline"
+        icon: "mdi:thermometer"
 
       - name: "Total Battery Charge"
         alt: "Battery Charge Total"


### PR DESCRIPTION
Updated icons of ZCS Azzurro HYD ZSS definition to match icons used in Home Assistant energy dashboard. Additional icons updated. Identification of correct sensor for energy dashboard configuration should be simpler.