### PR TITLE
Update kstar_hybrid.yaml

### DIFF
--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
@@ -342,7 +342,7 @@ parameters:
         registers: [3066]
         icon: "mdi:battery"
 
-        - name: "Battery 1"
+      - name: "Battery 1"
         update_interval: 5
         state_class: "measurement"
         uom: "%"
@@ -350,7 +350,7 @@ parameters:
         registers: [3450]
         icon: "mdi:battery"
 
-        - name: "Battery 2"
+      - name: "Battery 2"
         update_interval: 5
         state_class: "measurement"
         uom: "%"
@@ -358,7 +358,7 @@ parameters:
         registers: [3494]
         icon: "mdi:battery"
 
-        - name: "Battery 3"
+      - name: "Battery 3"
         update_interval: 5
         state_class: "measurement"
         uom: "%"

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
@@ -933,5 +933,5 @@ parameters:
         uom: "%"
         scale: 0.1
         rule: 1
-        registers: [3638]
+        registers: [3538]
         icon: "mdi:battery"

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
@@ -340,7 +340,6 @@ parameters:
         scale: 0.1
         rule: 1
         registers: [3066]
-        icon: "mdi:battery"
 
       - name: "Battery 1"
         update_interval: 5

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
@@ -905,3 +905,33 @@ parameters:
           - operator: subtract
             signed:
             registers: [3126]
+
+        - name: "Battery Pack 1 SOC"
+        update_interval: 5
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 0.1
+        rule: 1
+        registers: [3450]
+        icon: "mdi:battery"
+
+        - name: "Battery Pack 2 SOC"
+        update_interval: 5
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 0.1
+        rule: 1
+        registers: [3494]
+        icon: "mdi:battery"
+
+        - name: "Battery Pack 3 SOC"
+        update_interval: 5
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 0.1
+        rule: 1
+        registers: [3638]
+        icon: "mdi:battery"

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yaml
@@ -342,6 +342,30 @@ parameters:
         registers: [3066]
         icon: "mdi:battery"
 
+        - name: "Battery 1"
+        update_interval: 5
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [3450]
+        icon: "mdi:battery"
+
+        - name: "Battery 2"
+        update_interval: 5
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [3494]
+        icon: "mdi:battery"
+
+        - name: "Battery 3"
+        update_interval: 5
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [3538]
+        icon: "mdi:battery"
+
       - name: "Battery Temperature"
         update_interval: 30
         class: "temperature"
@@ -905,33 +929,3 @@ parameters:
           - operator: subtract
             signed:
             registers: [3126]
-
-        - name: "Battery Pack 1 SOC"
-        update_interval: 5
-        class: "battery"
-        state_class: "measurement"
-        uom: "%"
-        scale: 0.1
-        rule: 1
-        registers: [3450]
-        icon: "mdi:battery"
-
-        - name: "Battery Pack 2 SOC"
-        update_interval: 5
-        class: "battery"
-        state_class: "measurement"
-        uom: "%"
-        scale: 0.1
-        rule: 1
-        registers: [3494]
-        icon: "mdi:battery"
-
-        - name: "Battery Pack 3 SOC"
-        update_interval: 5
-        class: "battery"
-        state_class: "measurement"
-        uom: "%"
-        scale: 0.1
-        rule: 1
-        registers: [3538]
-        icon: "mdi:battery"


### PR DESCRIPTION
DATA FROM MODBUS SHEET
3450	PACKSOC		PACK1	%	U16	0~100	04H
3494	PACKSOC		PACK2	%	U16	0~100	04H
3638	PACKSOC		PACK3	%	U16	0~100	04H




To include individual Battery Pack SOCs.

This will allow users to see if the battery packs are balanced, the overall SOC of all batteries is an average percentage of all the cells.

I added these registers to the bottom of the YAML, unsure if the rules etc need adjusting

        - name: "Battery Pack 1 SOC"
        update_interval: 5
        class: "battery"
        state_class: "measurement"
        uom: "%"
        scale: 0.1
        rule: 1
        registers: [3450]
        icon: "mdi:battery"

        - name: "Battery Pack 2 SOC"
        update_interval: 5
        class: "battery"
        state_class: "measurement"
        uom: "%"
        scale: 0.1
        rule: 1
        registers: [3494]
        icon: "mdi:battery"

        - name: "Battery Pack 3 SOC"
        update_interval: 5
        class: "battery"
        state_class: "measurement"
        uom: "%"
        scale: 0.1
        rule: 1
        registers: [3638]
        icon: "mdi:battery"