### PR TITLE
Add Configuration to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,11 @@
 ### 🔧 Manually
 - Copy the contents of `custom_components/solarman` directory into the Home Assistant with exactly the same hirearchy within the `/config` directory
 
+## ⚙️ Configuration
+- In Home Assistant, go to Settings > Devices & services > Integrations
+- Click the `+ ADD INTEGRATION` button, search for and select "Solarman"
+- Enter the appropriate details (they should be autodiscovered under most circumstances) and submit
+
 ## 👤 Contributors
 <a href="https://github.com/davidrapan/ha-solarman/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=davidrapan/ha-solarman" />


### PR DESCRIPTION
This may be obvious to seasoned HA users, but it took me a long time to work out that after installing the Solarman integration I still needed a separate step to add it under Integrations (especially since autodiscovery is mentioned in various places). I propose adding the instructions to `readme.md`, but they would also work fine in the wiki.