### PR TITLE
Update zcs_azzurro-hyd-zss-hp.yaml

### DIFF
--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -534,6 +534,8 @@ parameters:
             value: "ID03 Grid Over Frequency Protection"
           - key: 8
             value: "ID04 Grid Under Frequency Protection"
+          - key: 10
+            value: "Off-Grid"
           - key: 16
             value: "ID05 Leakage current fault"
           - key: 32

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -141,6 +141,30 @@ parameters:
         registers: [0x0608]
         icon: "mdi:battery"
 
+      - name: "Battery DOD"
+        update_interval: 30
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [0x104D]
+        icon: "mdi:battery"
+
+      - name: "Battery EOD"
+        update_interval: 30
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [0x104E]
+        icon: "mdi:battery"
+
+      - name: "Battery EPS Buffer"
+        update_interval: 30
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [0x1052]
+        icon: "mdi:battery-low"
+
       - name: "Battery SOH"
         state_class: "measurement"
         uom: "%"
@@ -281,6 +305,24 @@ parameters:
         registers: [0x0504]
         icon: "mdi:home-lightning-bolt"
 
+      - name: "Load Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x050A]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Load Frequency"
+        class: "frequency"
+        state_class: "measurement"
+        uom: "Hz"
+        scale: 0.01
+        rule: 1
+        registers: [0x0507]
+        icon: "mdi:home-lightning-bolt"
+
       - name: "Today Energy Import"
         alt: Energy Purchase Today
         friendly_name: Today's Energy Import
@@ -328,6 +370,31 @@ parameters:
         rule: 3
         registers: [0x0693, 0x0692]
         icon: "mdi:home-export-outline"
+        validation:
+          min: 0.1
+
+      - name: "Today Load Consumption"
+        alt: "Today Power Consumption"
+        friendly_name: "Today's Load Consumption"
+        update_interval: 30
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.01
+        rule: 3
+        registers: [0x0689, 0x0688]
+        icon: "mdi:lightning-bolt"
+
+      - name: "Total Load Consumption"
+        alt: "Total Power Consumption"
+        update_interval: 30
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x068B, 0x068A]
+        icon: "mdi:lightning-bolt"
         validation:
           min: 0.1
 
@@ -387,6 +454,48 @@ parameters:
         rule: 1
         registers: [0x042B]
         icon: "mdi:omega"
+
+      - name: "Serial Number"
+        update_interval: 60
+        rule: 5
+        registers: [0x0445, 0x0446, 0x0447, 0x0448, 0x0449, 0x044A, 0x044B, 0x044C] # serial number 17th to 20th digits are in 0x0470 and 0x0471
+        icon: "mdi:barcode"
+
+      - name: "Hardware Version"
+        update_interval: 60
+        rule: 5
+        registers: [0x044D, 0x044E]
+        icon: "mdi:alpha-v"
+
+      - name: "Software Version Master"
+        update_interval: 60
+        rule: 5
+        registers: [0x0453, 0x0454, 0x0455, 0x0456]
+        icon: "mdi:alpha-v"
+
+      - name: "Software Version Slave"
+        update_interval: 60
+        rule: 5
+        registers: [0x0457, 0x0458, 0x0459, 0x045A]
+        icon: "mdi:alpha-v"
+
+      - name: "Safety Version"
+        update_interval: 60
+        rule: 5
+        registers: [0x045B, 0x045C]
+        icon: "mdi:alpha-v"
+
+      - name: "Safety Firmware Version"
+        update_interval: 60
+        rule: 5
+        registers: [0x0460, 0x0461, 0x0462, 0x0463]
+        icon: "mdi:alpha-v"
+
+      - name: "Safety Hardware Version"
+        update_interval: 60
+        rule: 5
+        registers: [0x0464, 0x0465]
+        icon: "mdi:alpha-v"
 
   - group: Alarm
     items:


### PR DESCRIPTION
### New sensors:
- Battery DOD (depth of discharge)
- Battery EOD (end of discharge)
- Battery EPS buffer
- Load Voltage
- Load Frequency
- Today Load Consumption
- Total Load Consumption
- Serial Number (inverter)
- Hardware Version
- Software Version Master
- Software Version Slave
- Safety Version
- Safety Firmware Version
- Safety Hardware Version

### New value for sensor "Fault 1":
- Off-Grid

This value is not documented in Sofar specs, it may be equivalent to "Grid Failure" in Huawei inverters but it doesn't have its own error ID.
It's fired when the power grid experiences an outage, the AC power cable is disconnected or the AC circuit breaker is OFF, and "Device State" is "Emergency power supply"
It's only fired when the "Load" port has a connection, otherwise you'll only get a "ID02 Grid Under Voltage Protection", so it's more of a "state" then an actual "fault".