### PR TITLE
Fixes for zcs_azzurro-hyd-zss-hp.yaml

### DIFF
--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -208,6 +208,7 @@ parameters:
           min: 0.1
 
       - name: "Battery Cycles"
+        state_class: "measurement"
         uom: "Charges"
         rule: 1
         registers: [0x060A]

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -499,6 +499,7 @@ parameters:
         icon: "mdi:alpha-v"
 
   - group: Alarm
+    update_interval: 5
     items:
       - name: "Device Alarm"
         update_interval: 30
@@ -520,7 +521,6 @@ parameters:
           ]
 
       - name: "Fault 1"
-        update_interval: 30
         rule: 1
         registers: [0x0405]
         icon: "mdi:wrench"
@@ -563,7 +563,6 @@ parameters:
             value: "ID16"
 
       - name: "Fault 2"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x0406]
@@ -604,7 +603,6 @@ parameters:
             value: "ID32"
 
       - name: "Fault 3"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x0407]
@@ -645,7 +643,6 @@ parameters:
             value: "ID048 Serial number error"
 
       - name: "Fault 4"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x0408]
@@ -686,7 +683,6 @@ parameters:
             value: "ID064 "
 
       - name: "Fault 5"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x0409]
@@ -727,7 +723,6 @@ parameters:
             value: "ID080 "
 
       - name: "Fault 6"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x040A]
@@ -768,7 +763,6 @@ parameters:
             value: "ID096 "
 
       - name: "Fault 7"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x040B]
@@ -809,7 +803,6 @@ parameters:
             value: "ID112 Overload protection 3"
 
       - name: "Fault 8"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x040C]
@@ -850,7 +843,6 @@ parameters:
             value: "ID128 "
 
       - name: "Fault 9"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x040D]
@@ -891,7 +883,6 @@ parameters:
             value: "ID144 "
 
       - name: "Fault 10"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x040E]
@@ -932,7 +923,6 @@ parameters:
             value: "ID160 Lithium battery 4 communication failure"
 
       - name: "Fault 11"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x040F]
@@ -973,7 +963,6 @@ parameters:
             value: "ID176 Meter communication failure"
 
       - name: "Fault 12"
-        update_interval: 30
         rule: 1
         icon: "mdi:wrench"
         registers: [0x0410]

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -449,7 +449,7 @@ parameters:
         icon: "mdi:thermometer"
 
       - name: "Insulation Resistance"
-        update_interval: 300
+        update_interval: 30
         state_class: "measurement"
         uom: "kΩ"
         rule: 1

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -534,6 +534,8 @@ parameters:
             value: "ID03 Grid Over Frequency Protection"
           - key: 8
             value: "ID04 Grid Under Frequency Protection"
+          - key: 10
+            value: "Off-Grid"
           - key: 16
             value: "ID05 Leakage current fault"
           - key: 32

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -141,6 +141,30 @@ parameters:
         registers: [0x0608]
         icon: "mdi:battery"
 
+      - name: "Battery DOD"
+        update_interval: 30
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [0x104D]
+        icon: "mdi:battery"
+
+      - name: "Battery EOD"
+        update_interval: 30
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [0x104E]
+        icon: "mdi:battery"
+
+      - name: "Battery EPS Buffer"
+        update_interval: 30
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [0x1052]
+        icon: "mdi:battery-low"
+
       - name: "Battery SOH"
         state_class: "measurement"
         uom: "%"
@@ -281,6 +305,24 @@ parameters:
         registers: [0x0504]
         icon: "mdi:home-lightning-bolt"
 
+      - name: "Load Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x050A]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Load Frequency"
+        class: "frequency"
+        state_class: "measurement"
+        uom: "Hz"
+        scale: 0.01
+        rule: 1
+        registers: [0x0507]
+        icon: "mdi:home-lightning-bolt"
+
       - name: "Today Energy Import"
         alt: Energy Purchase Today
         friendly_name: Today's Energy Import
@@ -328,6 +370,31 @@ parameters:
         rule: 3
         registers: [0x0693, 0x0692]
         icon: "mdi:home-export-outline"
+        validation:
+          min: 0.1
+
+      - name: "Today Load Consumption"
+        alt: "Today Power Consumption"
+        friendly_name: "Today's Load Consumption"
+        update_interval: 30
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.01
+        rule: 3
+        registers: [0x0689, 0x0688]
+        icon: "mdi:lightning-bolt"
+
+      - name: "Total Load Consumption"
+        alt: "Total Power Consumption"
+        update_interval: 30
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x068B, 0x068A]
+        icon: "mdi:lightning-bolt"
         validation:
           min: 0.1
 
@@ -387,6 +454,48 @@ parameters:
         rule: 1
         registers: [0x042B]
         icon: "mdi:omega"
+
+      - name: "Serial Number"
+        update_interval: 60
+        rule: 5
+        registers: [0x0445, 0x0446, 0x0447, 0x0448, 0x0449, 0x044A, 0x044B, 0x044C] # serial number 17th to 20th digits are in 0x0470 and 0x0471
+        icon: "mdi:barcode"
+
+      - name: "Hardware Version"
+        update_interval: 60
+        rule: 5
+        registers: [0x044D, 0x044E]
+        icon: "mdi:alpha-v"
+
+      - name: "Software Version Master"
+        update_interval: 60
+        rule: 5
+        registers: [0x0453, 0x0454, 0x0455, 0x0456]
+        icon: "mdi:alpha-v"
+
+      - name: "Software Version Slave"
+        update_interval: 60
+        rule: 5
+        registers: [0x0457, 0x0458, 0x0459, 0x045A]
+        icon: "mdi:alpha-v"
+
+      - name: "Safety Version"
+        update_interval: 60
+        rule: 5
+        registers: [0x045B, 0x045C]
+        icon: "mdi:alpha-v"
+
+      - name: "Safety Firmware Version"
+        update_interval: 60
+        rule: 5
+        registers: [0x0460, 0x0461, 0x0462, 0x0463]
+        icon: "mdi:alpha-v"
+
+      - name: "Safety Hardware Version"
+        update_interval: 60
+        rule: 5
+        registers: [0x0464, 0x0465]
+        icon: "mdi:alpha-v"
 
   - group: Alarm
     items:

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -403,7 +403,6 @@ parameters:
     update_interval: 5
     items:
       - name: "Device State"
-        update_interval: 30
         class: "enum"
         rule: 1
         registers: [0x0404]

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -415,13 +415,13 @@ parameters:
           - key: 0x0002
             value: "Grid connected"
           - key: 0x0003
-            value: "Grid UFP"
-          - key: 0x0004
             value: "Emergency power supply"
-          - key: 0x0005
+          - key: 0x0004
             value: "Recoverable fault"
-          - key: 0x0006
+          - key: 0x0005
             value: "Permanent fault"
+          - key: 0x0006
+            value: "Upgrade"
           - key: 0x0007
             value: "Self-charging"
 

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -176,8 +176,8 @@ parameters:
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
-        #se non funziona cambia questo in 2
-        rule: 1
+        # change this to 1 if it doesn't work
+        rule: 2
         registers: [0x0607]
         icon: "mdi:thermometer"
 

--- a/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
+++ b/custom_components/solarman/inverter_definitions/zcs_azzurro-hyd-zss-hp.yaml
@@ -166,6 +166,7 @@ parameters:
         icon: "mdi:battery-low"
 
       - name: "Battery SOH"
+        update_interval: 30
         state_class: "measurement"
         uom: "%"
         rule: 1
@@ -208,6 +209,7 @@ parameters:
           min: 0.1
 
       - name: "Battery Cycles"
+        update_interval: 30
         state_class: "measurement"
         uom: "Charges"
         rule: 1


### PR DESCRIPTION
_**Note**: this pull request requires my other branch ("giona_zcs_azzurro-hyd-zss-hp_new-sensors") to be merged first!_

### Device states didn't match Sofar specifications:
- 0x0003 should be "Emergency power supply" (was "Grid UFP" which doesn't exist in specs)
- 0x0004 should be "Recoverable fault" (was "Emergency power supply" which is actually 0x0003)
- 0x0005 should be "Permanent fault" (was "Recoverable fault" which is actually 0x0004)
- 0x0006 should be "Upgrade" (state - was "Permanent fault" which is actually 0x0005)

Please check the reference for register addres 0404 : https://github.com/user-attachments/files/17180102/SOFAR-G3.External.Modbus.Protocol-EN-V1.10.20220622.xlsx

### Battery
- Sensor "Battery Temperature": rule should be 2 as default (was 2 in Stephan Joubert's [home_assistant_solarman](https://github.com/StephanJoubert/home_assistant_solarman/blob/main/custom_components/solarman/inverter_definitions/sofar_g3hyd.yaml))
- Sensor "Battery Cycles" should have state class "measurement"

### Update intervals
- Device state and faults lowered to 5 (from 30): you probably want to know as soon as possible if your inverter has a problem...
- Insulation resistance lowered to 30 (from 300): you probably want to know as soon as possible if it drops below a threshold (300 was probably a typo)
- Battery cycles and SOH increased to 30 (from group default 5): they aren't updated frequently so there's little value in retrieving them every 5 seconds

