### PR TITLE
fix: Missing Battery Module 0 pack number in pylontech_Force-H

### DIFF
--- a/custom_components/solarman/inverter_definitions/pylontech_Force-H.yaml
+++ b/custom_components/solarman/inverter_definitions/pylontech_Force-H.yaml
@@ -262,6 +262,7 @@ parameters:
 
   - group: Battery Module 0
     hidden:
+    pack: 1
     items:
       - name: "Battery Module 0 Voltage"
         class: "voltage"


### PR DESCRIPTION
forgotten pack 1 in Battery Module 0