### PR TITLE
fix: Load Power class in sofar_tlx-g3

### DIFF
--- a/custom_components/solarman/inverter_definitions/sofar_tlx-g3.yaml
+++ b/custom_components/solarman/inverter_definitions/sofar_tlx-g3.yaml
@@ -152,7 +152,7 @@ parameters:
   - group: Load
     items:
       - name: "Load Power"
-        class: "energy"
+        class: "power"
         uom: "kW"
         scale: 0.01
         rule: 1


### PR DESCRIPTION
Fix of the error:

Entity sensor.inverter_load_power (<class 'custom_components.solarman.sensor.SolarmanSensor'>) is using native unit of measurement 'kW' which is not a valid unit for the device class ('energy') it is using.