### PR TITLE
Afore T4: Several updates (BNT series)

### DIFF
--- a/custom_components/solarman/inverter_definitions/afore_BNTxxxKTL-2mppt.yaml
+++ b/custom_components/solarman/inverter_definitions/afore_BNTxxxKTL-2mppt.yaml
@@ -15,7 +15,7 @@ default:
 parameters:
   - group: PV
     items:
-      - name: PV Power
+      - name: "PV Power"
         alt: DC Power
         mppt: 1
         description: Combined power of all inputs
@@ -35,7 +35,7 @@ parameters:
               registers: [0x000A]
         icon: "mdi:solar-power-variant"
 
-      - name: PV1 Power
+      - name: "PV1 Power"
         alt: DC1 Power
         mppt: 1
         class: "power"
@@ -68,12 +68,12 @@ parameters:
         class: "current"
         state_class: "measurement"
         uom: "A"
-        scale: 0.01
+        scale: 0.1
         rule: 1
         registers: [0x0008]
         icon: "mdi:solar-power-variant"
 
-      - name: PV2 Power
+      - name: "PV2 Power"
         alt: DC2 Power
         mppt: 2
         class: "power"
@@ -106,38 +106,12 @@ parameters:
         class: "current"
         state_class: "measurement"
         uom: "A"
-        scale: 0.01
+        scale: 0.1
         rule: 1
         registers: [0x000A]
         icon: "mdi:solar-power-variant"
 
-      - name: "Today Production"
-        friendly_name: Today's Production
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "Wh"
-        rule: 1
-        registers: [0x000F]
-        icon: "mdi:solar-power"
-
-      - name: "Total Production"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "Wh"
-        rule: 3
-        registers: [0x0015, 0x0014]
-        icon: "mdi:solar-power"
-        validation:
-          min: 0.1
-
-      - name: "Today Production time"
-        state_class: "measurement"
-        uom: "s"
-        rule: 1
-        registers: [0x0013]
-        icon: "mdi:clock-outline"
-
-  - group: Output
+  - group: Grid
     items:
       - name: "L1 Voltage"
         l: 1
@@ -174,7 +148,7 @@ parameters:
         class: "current"
         state_class: "measurement"
         uom: "A"
-        scale: 0.01
+        scale: 0.1
         rule: 1
         registers: [0x0004]
         icon: "mdi:home-lightning-bolt"
@@ -184,7 +158,7 @@ parameters:
         class: "current"
         state_class: "measurement"
         uom: "A"
-        scale: 0.01
+        scale: 0.1
         rule: 1
         registers: [0x0005]
         icon: "mdi:home-lightning-bolt"
@@ -194,10 +168,86 @@ parameters:
         class: "current"
         state_class: "measurement"
         uom: "A"
-        scale: 0.01
+        scale: 0.1
         rule: 1
         registers: [0x0006]
         icon: "mdi:home-lightning-bolt"
+
+      - name: "L1 Power"
+        l: 1
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        rule: 1
+        digits: 3
+        scale: 0.1
+        registers: [0x0001, 0x0004]
+        sensors:
+          - registers: [0x0001]
+            multiply:
+              registers: [0x0004]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "L2 Power"
+        l: 2
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        rule: 1
+        digits: 3
+        scale: 0.1
+        registers: [0x0002, 0x0005]
+        sensors:
+          - registers: [0x0002]
+            multiply:
+              registers: [0x0005]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "L3 Power"
+        l: 3
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        rule: 1
+        digits: 3
+        scale: 0.1
+        registers: [0x0003, 0x0006]
+        sensors:
+          - registers: [0x0003]
+            multiply:
+              registers: [0x0006]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: Power
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        rule: 1
+        registers: [0x0011, 0x0010]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: Power losses
+        description: Includes consumption of the inverter device itself as well AC/DC conversion losses
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        rule: 1
+        digits: 3
+        registers: [0x0007, 0x0008, 0x0009, 0x000A, 0x0010, 0x0011]
+        uint: enforce
+        sensors:
+          - registers: [0x0007]
+            scale: 0.1
+            multiply:
+              registers: [0x0008]
+              scale: 0.1
+          - registers: [0x0009]
+            scale: 0.1
+            multiply:
+              registers: [0x000A]
+              scale: 0.1
+          - operator: subtract
+            registers: [0x0011, 0x0010]
 
       - name: "Frequency"
         class: "frequency"
@@ -208,8 +258,214 @@ parameters:
         registers: [0x000B]
         icon: "mdi:home-lightning-bolt"
 
+  - group: Device
+    update_interval: 60
+    items:
+      - name: "Inverter PowerDown"
+        icon: "mdi:wrench"
+        rule: 1
+        registers: [0x0000]
+        mask: 0x2
+        lookup:
+          - key: 0
+            value: "off"
+          - key: 2
+            value: "on"
+
+      - name: "Inverter start"
+        icon: "mdi:wrench"
+        rule: 1
+        registers: [0x0000]
+        mask: 0x100
+        lookup:
+          - key: 0
+            value: "off"
+          - key: 256
+            value: "on"
+
+      - name: "Inverter grid connection"
+        icon: "mdi:wrench"
+        rule: 1
+        registers: [0x0000]
+        mask: 0x200
+        lookup:
+          - key: 0
+            value: "off"
+          - key: 512
+            value: "on"
+
+      - name: "Inverter grid state"
+        icon: "mdi:wrench"
+        rule: 1
+        registers: [0x0000]
+        mask: 0x400
+        lookup:
+          - key: 0
+            value: "Abnormal"
+          - key: 1024
+            value: "Normal"
+
+      - name: "Inverter run"
+        icon: "mdi:wrench"
+        rule: 1
+        registers: [0x0000]
+        mask: 0x2000
+        lookup:
+          - key: 0
+            value: "off"
+          - key: 8192
+            value: "on"
+
+      - name: E01
+        class: "enum"
+        rule: 1
+        registers: [0x0016]
+        icon: "mdi:state-machine"
+        lookup:
+          - key: 0
+            value: "No error"
+          - key: 1
+            value: "IntFaultE"
+          - key: 2
+            value: "IntFaultD"
+          - key: 4
+            value: "IntFaultC"
+          - key: 8
+            value: "IntFaultB"
+          - key: 16
+            value: "IntFaultA"
+          - key: 32
+            value: "IntFaultN"
+          - key: 256
+            value: "IntFaultM"
+          - key: 512
+            value: "IntFaultL"
+          - key: 1024
+            value: "IntFaultK"
+          - key: 2048
+            value: "IntFaultJ"
+          - key: 16384
+            value: "IntFaultG"
+
+      - name: E02
+        class: "enum"
+        rule: 1
+        registers: [0x0017]
+        icon: "mdi:state-machine"
+        lookup:
+          - key: 0
+            value: "No error"
+          - key: 256
+            value: "IntProtectT"
+          - key: 512
+            value: "IntProtectU"
+
+      - name: E03
+        class: "enum"
+        rule: 1
+        registers: [0x0018]
+        icon: "mdi:state-machine"
+        lookup:
+          - key: 0
+            value: "No error"
+          - key: 1
+            value: "IntProtectN"
+          - key: 2
+            value: "GridV.OutLim"
+          - key: 4
+            value: "EmergencyStp"
+          - key: 8
+            value: "IntProtectM"
+          - key: 16
+            value: "IntProtectL"
+          - key: 32
+            value: "Ac.ConErr"
+          - key: 64
+            value: "IntProtectK"
+          - key: 128
+            value: "IntProtectJ"
+          - key: 256
+            value: "IntProtectS"
+          - key: 512
+            value: "IntProtectR"
+          - key: 1024
+            value: "IntProtectQ"
+          - key: 2048
+            value: "IsolationErr"
+          - key: 4096
+            value: "GFCI.Err"
+          - key: 8192
+            value: "IntProtectP"
+          - key: 16384
+            value: "PV.Reverse"
+          - key: 32768
+            value: "IntProtectO"
+
+      - name: E04
+        class: "enum"
+        rule: 1
+        registers: [0x0019]
+        icon: "mdi:state-machine"
+        lookup:
+          - key: 0
+            value: "No error"
+          - key: 1
+            value: "GridV.OutLim"
+          - key: 2
+            value: "IntProtectC"
+          - key: 4
+            value: "GridF.OutLim"
+          - key: 8
+            value: "GridF.OutLim"
+          - key: 16
+            value: "GridV.OutLim"
+          - key: 32
+            value: "IntProtectB"
+          - key: 64
+            value: "TempOver"
+          - key: 128
+            value: "IntProtectA"
+          - key: 256
+            value: "IntProtectl"
+          - key: 512
+            value: "IntProtectH"
+          - key: 1024
+            value: "IntProtectG"
+          - key: 2048
+            value: "IntProtectF"
+          - key: 4096
+            value: "IntProtectE"
+          - key: 8192
+            value: "PVVoltOver"
+          - key: 16384
+            value: "IntProtectD"
+          - key: 32768
+            value: "GridV.OutLim"
+
+      - name: E05
+        class: "enum"
+        rule: 1
+        registers: [0x001A]
+        icon: "mdi:state-machine"
+        lookup:
+          - key: 0
+            value: "No error"
+          - key: 256
+            value: "ExtFanErr"
+          - key: 512
+            value: "IntFanErr"
+          - key: 1024
+            value: "SPICommErr"
+          - key: 2048
+            value: "EepromErr"
+          - key: 4096
+            value: "PVBrkerOpen"
+          - key: 8192
+            value: "TempSensorErr"
+
       - name: "Temperature"
         class: "temperature"
+        state_class: "measurement"
         uom: "°C"
         scale: 0.1
         rule: 1
@@ -223,30 +479,31 @@ parameters:
         rule: 1
         registers: [0x000D]
 
-      - name: Power
-        class: "power"
-        state_class: "measurement"
-        uom: "W"
+  - group: Meter
+    update_interval: 30
+    items:
+      - name: "Today Production"
+        friendly_name: "Today's Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
         rule: 1
-        registers: [0x0011]
-        icon: "mdi:home-lightning-bolt"
+        registers: [0x000F, 0x000E]
+        icon: "mdi:solar-power"
 
-      - name: Power losses
-        description: Includes consumption of the inverter device itself as well AC/DC conversion losses
-        class: "power"
+      - name: "Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
+        rule: 3
+        registers: [0x0015, 0x0014]
+        icon: "mdi:solar-power"
+        validation:
+          min: 0.1
+
+      - name: "Today Production time"
         state_class: "measurement"
-        uom: "W"
+        uom: "s"
         rule: 1
-        digits: 3
-        scale: 0.1
-        registers: [0x0007, 0x0008, 0x0009, 0x000A, 0x0011]
-        uint: enforce
-        sensors:
-          - registers: [0x0007]
-            multiply:
-              registers: [0x0008]
-          - registers: [0x0009]
-            multiply:
-              registers: [0x000A]
-          - operator: subtract
-            registers: [0x0011]
+        registers: [0x0013, 0x0012]
+        icon: "mdi:clock-outline"

--- a/custom_components/solarman/inverter_definitions/afore_BNTxxxKTL-2mppt.yaml
+++ b/custom_components/solarman/inverter_definitions/afore_BNTxxxKTL-2mppt.yaml
@@ -13,9 +13,116 @@ default:
   digits: 6
 
 parameters:
+  - group: Grid
+    items:
+      - name: "Grid L1 Voltage"
+        l: 1
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0001]
+
+      - name: "Grid L2 Voltage"
+        l: 2
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0002]
+
+      - name: "Grid L3 Voltage"
+        l: 3
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0003]
+
+      - name: "Grid L1 Current"
+        l: 1
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x0004]
+
+      - name: "Grid L2 Current"
+        l: 2
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x0005]
+
+      - name: "Grid L3 Current"
+        l: 3
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x0006]
+
+      - name: "Grid L1 Power"
+        l: 1
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        rule: 1
+        digits: 3
+        scale: 0.1
+        registers: [0x0001, 0x0004]
+        sensors:
+          - registers: [0x0001]
+            multiply:
+              registers: [0x0004]
+
+      - name: "Grid L2 Power"
+        l: 2
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        rule: 1
+        digits: 3
+        scale: 0.1
+        registers: [0x0002, 0x0005]
+        sensors:
+          - registers: [0x0002]
+            multiply:
+              registers: [0x0005]
+
+      - name: "Grid L3 Power"
+        l: 3
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        rule: 1
+        digits: 3
+        scale: 0.1
+        registers: [0x0003, 0x0006]
+        sensors:
+          - registers: [0x0003]
+            multiply:
+              registers: [0x0006]
+
+      - name: "Grid Frequency"
+        class: "frequency"
+        state_class: "measurement"
+        uom: "Hz"
+        scale: 0.1
+        rule: 1
+        registers: [0x000D]
+        icon: "mdi:home-lightning-bolt"
+
   - group: PV
     items:
-      - name: "PV Power"
+      - name: PV Power
         alt: DC Power
         mppt: 1
         description: Combined power of all inputs
@@ -25,7 +132,7 @@ parameters:
         rule: 1
         digits: 3
         scale: 0.1
-        registers: [0x0007, 0x0008, 0x0009, 0x000A]
+        registers: [0x0007, 0x0008, 0x0009, 0x000A, 0x000B, 0x000C]
         sensors:
           - registers: [0x0007]
             multiply:
@@ -33,9 +140,12 @@ parameters:
           - registers: [0x0009]
             multiply:
               registers: [0x000A]
+          - registers: [0x000B]
+            multiply:
+              registers: [0x000C]
         icon: "mdi:solar-power-variant"
 
-      - name: "PV1 Power"
+      - name: PV1 Power
         alt: DC1 Power
         mppt: 1
         class: "power"
@@ -73,7 +183,7 @@ parameters:
         registers: [0x0008]
         icon: "mdi:solar-power-variant"
 
-      - name: "PV2 Power"
+      - name: PV2 Power
         alt: DC2 Power
         mppt: 2
         class: "power"
@@ -111,120 +221,68 @@ parameters:
         registers: [0x000A]
         icon: "mdi:solar-power-variant"
 
-  - group: Grid
+      - name: PV3 Power
+        alt: DC3 Power
+        mppt: 3
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        rule: 1
+        digits: 3
+        scale: 0.1
+        registers: [0x000B, 0x000C]
+        sensors:
+          - registers: [0x000B]
+            multiply:
+              registers: [0x000C]
+        icon: "mdi:solar-power-variant"
+
+      - name: "PV3 Voltage"
+        alt: DC3 Voltage
+        mppt: 3
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x000B]
+        icon: "mdi:solar-power-variant"
+
+      - name: "PV3 Current"
+        alt: DC3 Current
+        mppt: 3
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x000C]
+        icon: "mdi:solar-power-variant"
+
+  - group: Other
     items:
-      - name: "L1 Voltage"
-        l: 1
-        class: "voltage"
+      - name: "DC Temperature"
+        class: "temperature"
         state_class: "measurement"
-        uom: "V"
+        uom: "°C"
         scale: 0.1
         rule: 1
-        registers: [0x0001]
-        icon: "mdi:home-lightning-bolt"
+        registers: [0x000E]
 
-      - name: "L2 Voltage"
-        l: 2
-        class: "voltage"
+      - name: "Temperature"
+        class: "temperature"
         state_class: "measurement"
-        uom: "V"
+        uom: "°C"
         scale: 0.1
         rule: 1
-        registers: [0x0002]
-        icon: "mdi:home-lightning-bolt"
-
-      - name: "L3 Voltage"
-        l: 3
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [0x0003]
-        icon: "mdi:home-lightning-bolt"
-
-      - name: "L1 Current"
-        l: 1
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.1
-        rule: 1
-        registers: [0x0004]
-        icon: "mdi:home-lightning-bolt"
-
-      - name: "L2 Current"
-        l: 2
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.1
-        rule: 1
-        registers: [0x0005]
-        icon: "mdi:home-lightning-bolt"
-
-      - name: "L3 Current"
-        l: 3
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.1
-        rule: 1
-        registers: [0x0006]
-        icon: "mdi:home-lightning-bolt"
-
-      - name: "L1 Power"
-        l: 1
-        class: "power"
-        state_class: "measurement"
-        uom: "W"
-        rule: 1
-        digits: 3
-        scale: 0.1
-        registers: [0x0001, 0x0004]
-        sensors:
-          - registers: [0x0001]
-            multiply:
-              registers: [0x0004]
-        icon: "mdi:home-lightning-bolt"
-
-      - name: "L2 Power"
-        l: 2
-        class: "power"
-        state_class: "measurement"
-        uom: "W"
-        rule: 1
-        digits: 3
-        scale: 0.1
-        registers: [0x0002, 0x0005]
-        sensors:
-          - registers: [0x0002]
-            multiply:
-              registers: [0x0005]
-        icon: "mdi:home-lightning-bolt"
-
-      - name: "L3 Power"
-        l: 3
-        class: "power"
-        state_class: "measurement"
-        uom: "W"
-        rule: 1
-        digits: 3
-        scale: 0.1
-        registers: [0x0003, 0x0006]
-        sensors:
-          - registers: [0x0003]
-            multiply:
-              registers: [0x0006]
-        icon: "mdi:home-lightning-bolt"
+        registers: [0x000F]
 
       - name: Power
         class: "power"
         state_class: "measurement"
         uom: "W"
         rule: 1
-        registers: [0x0011, 0x0010]
-        icon: "mdi:home-lightning-bolt"
+        registers: [0x0013, 0x0012]
 
       - name: Power losses
         description: Includes consumption of the inverter device itself as well AC/DC conversion losses
@@ -233,7 +291,7 @@ parameters:
         uom: "W"
         rule: 1
         digits: 3
-        registers: [0x0007, 0x0008, 0x0009, 0x000A, 0x0010, 0x0011]
+        registers: [0x0007, 0x0008, 0x0009, 0x000A, 0x0012, 0x0013]
         uint: enforce
         sensors:
           - registers: [0x0007]
@@ -247,83 +305,82 @@ parameters:
               registers: [0x000A]
               scale: 0.1
           - operator: subtract
-            registers: [0x0011, 0x0010]
+            registers: [0x0013, 0x0012]
 
-      - name: "Frequency"
-        class: "frequency"
-        state_class: "measurement"
-        uom: "Hz"
-        scale: 0.1
+  - group: Energy
+    items:
+      - name: "Today Production"
+        friendly_name: "Today's Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
         rule: 1
-        registers: [0x000B]
-        icon: "mdi:home-lightning-bolt"
+        registers: [0x0011, 0x0010]
+        icon: "mdi:solar-power"
+
+      - name: "Today Production time"
+        state_class: "measurement"
+        uom: "s"
+        rule: 1
+        registers: [0x0014, 0x0013]
+        icon: "mdi:clock-outline"
+
+      - name: "Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
+        rule: 3
+        registers: [0x0017, 0x0016]
+        icon: "mdi:solar-power"
+        validation:
+          min: 0.1
 
   - group: Device
-    update_interval: 60
     items:
-      - name: "Inverter PowerDown"
-        icon: "mdi:wrench"
-        rule: 1
-        registers: [0x0000]
-        mask: 0x2
-        lookup:
-          - key: 0
-            value: "off"
-          - key: 2
-            value: "on"
-
-      - name: "Inverter start"
-        icon: "mdi:wrench"
-        rule: 1
-        registers: [0x0000]
-        mask: 0x100
-        lookup:
-          - key: 0
-            value: "off"
-          - key: 256
-            value: "on"
-
-      - name: "Inverter grid connection"
-        icon: "mdi:wrench"
-        rule: 1
-        registers: [0x0000]
-        mask: 0x200
-        lookup:
-          - key: 0
-            value: "off"
-          - key: 512
-            value: "on"
-
-      - name: "Inverter grid state"
-        icon: "mdi:wrench"
-        rule: 1
-        registers: [0x0000]
-        mask: 0x400
-        lookup:
-          - key: 0
-            value: "Abnormal"
-          - key: 1024
-            value: "Normal"
-
-      - name: "Inverter run"
-        icon: "mdi:wrench"
-        rule: 1
-        registers: [0x0000]
-        mask: 0x2000
-        lookup:
-          - key: 0
-            value: "off"
-          - key: 8192
-            value: "on"
-
-      - name: E01
+      - name: "Device State"
         class: "enum"
         rule: 1
-        registers: [0x0016]
+        registers: [0x0000]
         icon: "mdi:state-machine"
         lookup:
           - key: 0
-            value: "No error"
+            value: "Off"
+          - bit: 1
+            value: "Standby"
+          - bit: 8
+            value: "Starting"
+          - bit: 13
+            value: "Running"
+
+      - name: "Grid"
+        platform: "binary_sensor"
+        device_class: power
+        rule: 1
+        mask: 0x200
+        registers: [0x0000]
+
+      - name: "Grid State"
+        platform: binary_sensor
+        class: "problem"
+        rule: 1
+        mask: 0x400
+        registers: [0x0000]
+
+      - name: ""
+        platform: "binary_sensor"
+        device_class: running
+        rule: 1
+        mask: 0x2000
+        registers: [0x0000]
+
+      - name: Device Fault
+        class: "enum"
+        rule: 1
+        registers: [0x0018]
+        icon: "mdi:message-alert-outline"
+        lookup:
+          - key: 0
+            value: "OK"
           - key: 1
             value: "IntFaultE"
           - key: 2
@@ -347,27 +404,14 @@ parameters:
           - key: 16384
             value: "IntFaultG"
 
-      - name: E02
+      - name: "Device Alarm"
         class: "enum"
         rule: 1
-        registers: [0x0017]
-        icon: "mdi:state-machine"
+        registers: [0x001A, 0x001B, 0x001C, 0x0019]
+        icon: "mdi:alert-outline"
         lookup:
           - key: 0
-            value: "No error"
-          - key: 256
-            value: "IntProtectT"
-          - key: 512
-            value: "IntProtectU"
-
-      - name: E03
-        class: "enum"
-        rule: 1
-        registers: [0x0018]
-        icon: "mdi:state-machine"
-        lookup:
-          - key: 0
-            value: "No error"
+            value: "OK"
           - key: 1
             value: "IntProtectN"
           - key: 2
@@ -400,110 +444,49 @@ parameters:
             value: "PV.Reverse"
           - key: 32768
             value: "IntProtectO"
-
-      - name: E04
-        class: "enum"
-        rule: 1
-        registers: [0x0019]
-        icon: "mdi:state-machine"
-        lookup:
-          - key: 0
-            value: "No error"
-          - key: 1
+          - key: 65536
             value: "GridV.OutLim"
-          - key: 2
+          - key: 131072
             value: "IntProtectC"
-          - key: 4
+          - key: 262144
             value: "GridF.OutLim"
-          - key: 8
+          - key: 524288
             value: "GridF.OutLim"
-          - key: 16
+          - key: 1048576
             value: "GridV.OutLim"
-          - key: 32
+          - key: 2097152
             value: "IntProtectB"
-          - key: 64
+          - key: 4194304
             value: "TempOver"
-          - key: 128
+          - key: 8388608
             value: "IntProtectA"
-          - key: 256
+          - key: 16777216
             value: "IntProtectl"
-          - key: 512
+          - key: 33554432
             value: "IntProtectH"
-          - key: 1024
+          - key: 67108864
             value: "IntProtectG"
-          - key: 2048
+          - key: 134217728
             value: "IntProtectF"
-          - key: 4096
+          - key: 268435456
             value: "IntProtectE"
-          - key: 8192
+          - key: 536870912
             value: "PVVoltOver"
-          - key: 16384
+          - key: 1073741824
             value: "IntProtectD"
-          - key: 32768
-            value: "GridV.OutLim"
-
-      - name: E05
-        class: "enum"
-        rule: 1
-        registers: [0x001A]
-        icon: "mdi:state-machine"
-        lookup:
-          - key: 0
-            value: "No error"
-          - key: 256
+          - key: 549755813888
             value: "ExtFanErr"
-          - key: 512
+          - key: 1099511627776
             value: "IntFanErr"
-          - key: 1024
+          - key: 2199023255552
             value: "SPICommErr"
-          - key: 2048
+          - key: 4398046511104
             value: "EepromErr"
-          - key: 4096
+          - key: 8796093022208
             value: "PVBrkerOpen"
-          - key: 8192
+          - key: 17592186044416
             value: "TempSensorErr"
-
-      - name: "Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        registers: [0x000C]
-
-      - name: "DC Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        registers: [0x000D]
-
-  - group: Meter
-    update_interval: 30
-    items:
-      - name: "Today Production"
-        friendly_name: "Today's Production"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "Wh"
-        rule: 1
-        registers: [0x000F, 0x000E]
-        icon: "mdi:solar-power"
-
-      - name: "Total Production"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "Wh"
-        rule: 3
-        registers: [0x0015, 0x0014]
-        icon: "mdi:solar-power"
-        validation:
-          min: 0.1
-
-      - name: "Today Production time"
-        state_class: "measurement"
-        uom: "s"
-        rule: 1
-        registers: [0x0013, 0x0012]
-        icon: "mdi:clock-outline"
+          - key: 18014398509481984
+            value: "IntProtectT"
+          - key: 36028797018963968
+            value: "IntProtectU"


### PR DESCRIPTION
- Added L1/L2/L3 power (calculated out of voltage and current)
- Current scale should be 0.1, not 0.01 - see reference document
- Fix in Power losses calculation (due to scale inheritance)
- Move Today/Total production to new group Energy
- Today production is now read from two registers
- Power is now read from two registers
- New Device group with status/error registers
- Rename Output group to Grid

*tested on Afore BNT010KTL ("T4" serial number)