### PR TITLE
Deye batteries: Add additional temperature sensors

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -2826,6 +2826,66 @@ parameters:
         registers: [0x2739]
         icon: "mdi:current-dc"
 
+      - name: "Battery 1 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x273B]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 1 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x273C]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 1 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x273D]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 1 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x273E]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
       - name: "Battery 1 Temperature"
         class: "temperature"
         state_class: "measurement"
@@ -2970,6 +3030,66 @@ parameters:
           min: 1
           max: 99
 
+      - name: "Battery 2 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2761]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 2 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2762]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 2 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2763]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 2 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2764]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
       - name: "Battery 2"
         class: "battery"
         state_class: "measurement"
@@ -3092,6 +3212,66 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x2786]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 3 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2787]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 3 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2788]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 3 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2789]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 3 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x278A]
         range:
           min: 0
           max: 3000
@@ -3227,6 +3407,66 @@ parameters:
         validation:
           min: -99
           max: 99
+      
+      - name: "Battery 4 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27AD]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 4 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27AE]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 4 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27AF]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 4 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27B0]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
 
       - name: "Battery 4"
         class: "battery"
@@ -3356,6 +3596,66 @@ parameters:
         validation:
           min: -99
           max: 99
+      
+      - name: "Battery 5 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27D3]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 5 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27D4]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 5 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27D5]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 5 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27D6]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
 
       - name: "Battery 5"
         class: "battery"
@@ -3479,6 +3779,66 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x27F8]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 6 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27F9]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 6 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27FA]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 6 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27FB]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 6 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x27FC]
         range:
           min: 0
           max: 3000
@@ -3615,6 +3975,66 @@ parameters:
           min: -99
           max: 99
 
+      - name: "Battery 7 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x281F]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 7 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2820]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 7 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2821]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 7 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2822]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
       - name: "Battery 7"
         class: "battery"
         state_class: "measurement"
@@ -3737,6 +4157,66 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x2844]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 8 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2845]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 8 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2846]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 8 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2847]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 8 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2848]
         range:
           min: 0
           max: 3000
@@ -3873,6 +4353,66 @@ parameters:
           min: -99
           max: 99
 
+      - name: "Battery 9 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x286B]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 9 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x286C]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 9 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x286D]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 9 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x286E]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
       - name: "Battery 9"
         class: "battery"
         state_class: "measurement"
@@ -3995,6 +4535,66 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x2890]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 10 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2891]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 10 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2892]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 10 MosMax Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2893]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 10 HeatMem Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x2894]
         range:
           min: 0
           max: 3000

--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -2856,7 +2856,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 1 MosMax Temperature"
+      - name: "Battery 1 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -2864,21 +2864,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x273D]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 1 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x273E]
         range:
           min: 0
           max: 3000
@@ -3060,7 +3045,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 2 MosMax Temperature"
+      - name: "Battery 2 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -3068,21 +3053,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x2763]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 2 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x2764]
         range:
           min: 0
           max: 3000
@@ -3249,7 +3219,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 3 MosMax Temperature"
+      - name: "Battery 3 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -3257,21 +3227,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x2789]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 3 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x278A]
         range:
           min: 0
           max: 3000
@@ -3438,7 +3393,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 4 MosMax Temperature"
+      - name: "Battery 4 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -3446,21 +3401,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x27AF]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 4 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x27B0]
         range:
           min: 0
           max: 3000
@@ -3627,7 +3567,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 5 MosMax Temperature"
+      - name: "Battery 5 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -3635,21 +3575,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x27D5]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 5 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x27D6]
         range:
           min: 0
           max: 3000
@@ -3816,7 +3741,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 6 MosMax Temperature"
+      - name: "Battery 6 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -3824,21 +3749,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x27FB]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 6 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x27FC]
         range:
           min: 0
           max: 3000
@@ -4005,7 +3915,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 7 MosMax Temperature"
+      - name: "Battery 7 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -4013,21 +3923,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x2821]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 7 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x2822]
         range:
           min: 0
           max: 3000
@@ -4194,7 +4089,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 8 MosMax Temperature"
+      - name: "Battery 8 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -4202,21 +4097,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x2847]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 8 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x2848]
         range:
           min: 0
           max: 3000
@@ -4383,7 +4263,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 9 MosMax Temperature"
+      - name: "Battery 9 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -4391,21 +4271,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x286D]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 9 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x286E]
         range:
           min: 0
           max: 3000
@@ -4572,7 +4437,7 @@ parameters:
           min: -99
           max: 99      
 
-      - name: "Battery 10 MosMax Temperature"
+      - name: "Battery 10 MOS Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -4580,21 +4445,6 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x2893]
-        range:
-          min: 0
-          max: 3000
-        validation:
-          min: -99
-          max: 99
-
-      - name: "Battery 10 HeatMem Temperature"
-        class: "temperature"
-        state_class: "measurement"
-        uom: "°C"
-        scale: 0.1
-        rule: 1
-        offset: 1000
-        registers: [0x2894]
         range:
           min: 0
           max: 3000
@@ -4731,6 +4581,51 @@ parameters:
           min: -99
           max: 99
 
+      - name: "Battery 11 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x28B7]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 11 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x28B8]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 11 MOS Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x28B9]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
       - name: "Battery 11"
         class: "battery"
         state_class: "measurement"
@@ -4853,6 +4748,51 @@ parameters:
         rule: 1
         offset: 1000
         registers: [0x28DC]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+
+      - name: "Battery 12 Max Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x28DD]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99
+      
+      - name: "Battery 12 Min Cell Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x28DE]
+        range:
+          min: 0
+          max: 3000
+        validation:
+          min: -99
+          max: 99      
+
+      - name: "Battery 12 MOS Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x28DF]
         range:
           min: 0
           max: 3000


### PR DESCRIPTION
* Max Cell Temperature
* Min Cell Temperature
* MosMax Temperature
* HeatMem Temperature (not sure about it. It is always at -40, but in the solarman-dashboard as well)

The registers were taken from MODBUS.RTU.V105.1-20231006. They are tested with a Deye LV 3-Phase Hybrid Inverter (Deye SUN-12K-SG04LP3-EU) and 4 x Deye AI-W5.1-B