### PR TITLE
Solis Hybrid allow write of Backup Battery SOC

### DIFF
--- a/custom_components/solarman/inverter_definitions/solis_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/solis_hybrid.yaml
@@ -781,10 +781,21 @@ parameters:
         icon: "mdi:battery-arrow-down"
 
       - name: "Backup Mode SOC"
+        platform: number
         state_class: "measurement"
+        code:
+          read: 0x03
+          write: 0x06
         uom: "%"
         rule: 1
         registers: [43024]
+        range: 
+          min: 0
+          max: 100
+        configurable:
+          min: 0
+          max: 100
+          step: 1
         icon: "mdi:battery"
 
       - name: "Overdischarge SOC"


### PR DESCRIPTION
A key parameter to automate these inverters tends to be the Backup Battery SOC. 

With "backup" mode enabled, this value essentially sets the desired battery hold level. 
Grid charge off, or on, decides if the inverter will naturally reach this value with solar and hold, or, charge from the grid to this value and hold. 
Automations can vary this value at specific times to control charge and discharge. 

There is little / no value of a sensor monitoring this value, its static, set by the user. 

This change turns this sensor value into a modifiable attribute. 
It does not work without https://github.com/davidrapan/ha-solarman/pull/570 