### PR TITLE
Add explicit error message when `_to_native_value is None`

### DIFF
--- a/custom_components/solarman/switch.py
+++ b/custom_components/solarman/switch.py
@@ -51,8 +51,14 @@ class SolarmanSwitchEntity(SolarmanWritableEntity, SwitchEntity):
                 self._value_bit = value["bit"]
 
     def _to_native_value(self, value: int) -> int:
-        if self._value_bit is not None:
-            return (self._attr_native_value & ~(1 << self._value_bit)) | (value << self._value_bit) 
+        if self._attr_native_value is None:
+            raise RuntimeError(
+                f"{self.name}: Cannot compute native value — _attr_native_value is None. "
+                "This likely means the entity has not received initial data from the device yet."
+            )
+
+       if self._value_bit is not None:
+            return (self._attr_native_value & ~(1 << self._value_bit)) | (value << self._value_bit)
         return value
 
     def _native_value(self) -> int:


### PR DESCRIPTION
As discussed [here](https://github.com/davidrapan/ha-solarman/issues/606), I believe it's helpful to include a more explicit error message. It provides a clearer hint about what's going wrong and makes troubleshooting easier.
