### PR TITLE
Deye 3P: Device relay mapping fix

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -1822,17 +1822,29 @@ parameters:
             value: "Off"
           - key: 0x0001
             value: "Inverter"
+          - key: 0x0003
+            value: "Inverter"
           - key: 0x0004
             value: "Grid"
           - key: 0x0005
+            value: "Inverter-Grid"
+          - key: 0x0006
+            value: "Grid"
+          - key: 0x0007
             value: "Inverter-Grid"
           - key: 0x0008
             value: "Generator"
           - key: 0x0009
             value: "Inverter-Gen"
+          - key: 0x000B
+            value: "Inverter-Gen"
           - key: 0x000C
             value: "Grid-Generator"
           - key: 0x000D
+            value: "Inv-Grid-Gen"
+          - key: 0x000E
+            value: "Grid-Generator"
+          - key: 0x000F
             value: "Inv-Grid-Gen"
           - key: "default"
             value: "Power Supply"

--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -1820,19 +1820,19 @@ parameters:
         lookup:
           - key: 0x0000
             value: "Off"
-          - key: [ 0x0001, 0x0003 ]
+          - key: [0x0001, 0x0003]
             value: "Inverter"
-          - key: [ 0x0004, 0x0006 ]
+          - key: [0x0004, 0x0006]
             value: "Grid"
-          - key: [ 0x0005, 0x0007 ]
+          - key: [0x0005, 0x0007]
             value: "Inverter-Grid"
           - key: 0x0008
             value: "Generator"
-          - key: [ 0x0009, 0x000B ]
+          - key: [0x0009, 0x000B]
             value: "Inverter-Gen"
-          - key: [ 0x000C, 0x000E ]
+          - key: [0x000C, 0x000E]
             value: "Grid-Generator"
-          - key: [ 0x000D, 0x000F ]
+          - key: [0x000D, 0x000F]
             value: "Inv-Grid-Gen"
           - key: "default"
             value: "Power Supply"

--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -1820,31 +1820,19 @@ parameters:
         lookup:
           - key: 0x0000
             value: "Off"
-          - key: 0x0001
+          - key: [ 0x0001, 0x0003 ]
             value: "Inverter"
-          - key: 0x0003
-            value: "Inverter"
-          - key: 0x0004
+          - key: [ 0x0004, 0x0006 ]
             value: "Grid"
-          - key: 0x0005
-            value: "Inverter-Grid"
-          - key: 0x0006
-            value: "Grid"
-          - key: 0x0007
+          - key: [ 0x0005, 0x0007 ]
             value: "Inverter-Grid"
           - key: 0x0008
             value: "Generator"
-          - key: 0x0009
+          - key: [ 0x0009, 0x000B ]
             value: "Inverter-Gen"
-          - key: 0x000B
-            value: "Inverter-Gen"
-          - key: 0x000C
+          - key: [ 0x000C, 0x000E ]
             value: "Grid-Generator"
-          - key: 0x000D
-            value: "Inv-Grid-Gen"
-          - key: 0x000E
-            value: "Grid-Generator"
-          - key: 0x000F
+          - key: [ 0x000D, 0x000F ]
             value: "Inv-Grid-Gen"
           - key: "default"
             value: "Power Supply"


### PR DESCRIPTION
In my inverter I've noticed that bit1 is set (according to [the docs](deye-device-relay-more-mappings) its "undefined" or "reserved"), thus existing mappings fail as they assume bit1 is always clear. I've duplicated all the existing mappings and added their version with bit1 set keeping the same "label" value.

<img width="694" alt="image" src="https://github.com/user-attachments/assets/ba7cb204-d232-4a06-ba43-5c46a0467367" />
