### PR TITLE
Fix address in power losses calculation for `sofar_g3{,hyd}.yaml`

### DIFF
--- a/custom_components/solarman/inverter_definitions/sofar_g3.yaml
+++ b/custom_components/solarman/inverter_definitions/sofar_g3.yaml
@@ -320,7 +320,7 @@ parameters:
           - registers: [0x0589]
           - operator: subtract
             signed:
-            registers: [0x0214]
+            registers: [0x0485]
 
       - name: "Grid Power"
         class: "power"

--- a/custom_components/solarman/inverter_definitions/sofar_g3hyd.yaml
+++ b/custom_components/solarman/inverter_definitions/sofar_g3hyd.yaml
@@ -474,7 +474,7 @@ parameters:
           - registers: [0x05C4]
           - operator: subtract
             signed:
-            registers: [0x0214]
+            registers: [0x0485]
 
       - name: "ReactivePower_Output_Total"
         class: "reactive_power"


### PR DESCRIPTION
Possibly a copy-paste issue from `sofar_wifikit`.

Without this change, on my ZCS I'm getting:
```
Failed setup, will retry: The data address received in the request is not an allowable address for the server.
```