### PR TITLE
Update max range of "Zero Export power" to allow negative values

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -280,7 +280,7 @@ parameters:
         registers: [0x0068]
         range:
           min: 0
-          max: 500
+          max: 65535
         icon: "mdi:transmission-tower-import"
 
       - name: "Battery Equalization Cycle"


### PR DESCRIPTION
By using a SUN-12K-SG04LP3-EU inverter with firmware 1135 it's possible to use negative zero export power. For example to set the zero export power to -20W we can set it to 65516. So for using negative 'Zero Export power' we need to have a higher limit for that setting.