### PR TITLE
fix: Remove battery temp update interval

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -2023,7 +2023,6 @@ parameters:
     items:
       # Battery - The temperature of battery 1
       - name: "Battery Temperature"
-        update_interval: 5
         class: "temperature"
         state_class: "measurement"
         uom: "°C"


### PR DESCRIPTION
**Summary:**
This PR updates the custom battery temperature polling interval by reverting to the default interval for the entire group. The current 5-second polling frequency interferes with Deye cloud communications, causing the batteries to be reported as unavailable.

**Related Issue:**
[#516](https://github.com/davidrapan/ha-solarman/issues/516)