### PR TITLE
Use the new writeback feature in deprecated-ish profile ❘ Sofar G3

### DIFF
--- a/custom_components/solarman/inverter_definitions/sofar_g3hyd.yaml
+++ b/custom_components/solarman/inverter_definitions/sofar_g3hyd.yaml
@@ -1323,33 +1323,42 @@ parameters:
         class: "power"
         state_class: "measurement"
         uom: "W"
-        rule: 2
+        rule: 4
         registers: [0x1188, 0x1187]
         range:
           min: -2147483648 
           max: 2147483647
+        writeback:
+          register: 0x1187
+          count: 6
 
       - name: "Passive: Minimum Battery power"
         platform: number
         class: "power"
         state_class: "measurement"
         uom: "W"
-        rule: 2
+        rule: 4
         registers: [0x118A, 0x1189]
         range:
           min: -2147483648 
           max: 2147483647
+        writeback:
+          register: 0x1187
+          count: 6
 
       - name: "Passive: Maximum Battery power"
         platform: number
         class: "power"
         state_class: "measurement"
         uom: "W"
-        rule: 2
+        rule: 4
         registers: [0x118C, 0x118B]
         range:
           min: -2147483648 
           max: 2147483647
+        writeback:
+          register: 0x1187
+          count: 6
 
   - group: Alarm
     items:


### PR DESCRIPTION
Use writebacks introduced in #813 to fix writing passive mode settings.

According to [SOFAR_Modbus_Protocol_English_G3_V1.22.only.3PH.xlsx](https://github.com/user-attachments/files/18220633/SOFAR_Modbus_Protocol_English_G3_V1.22.only.3PH.xlsx), all 3 passive mode related fields needs to be written at the same time.