### PR TITLE
Revert Battery SoC & Temperature scaling ❘ Megarevo

### DIFF
--- a/custom_components/solarman/inverter_definitions/megarevo_r-3h.yaml
+++ b/custom_components/solarman/inverter_definitions/megarevo_r-3h.yaml
@@ -107,7 +107,7 @@ parameters:
         class: "battery"
         state_class: "measurement"
         uom: "%"
-        scale: 0.01
+        scale: 0.1
         rule: 1
         registers: [0x3145]
 
@@ -115,7 +115,7 @@ parameters:
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
-        scale: 0.01
+        scale: 0.1
         rule: 1
         registers: [0x3146]
 


### PR DESCRIPTION
I opened issue #871 . As a result "scale" was added to battery soc and battery temperature. But they are still displayed incorrectly.  These values that I am now trying to merge were tested on my local inverter definitions and they are now displaying properly.

Fixes #871