### PR TITLE
Fix PV Power sensor ❘ Megarevo 

### DIFF
--- a/custom_components/solarman/inverter_definitions/megarevo_r-3h.yaml
+++ b/custom_components/solarman/inverter_definitions/megarevo_r-3h.yaml
@@ -22,8 +22,13 @@ parameters:
         mppt: 1
         state_class: "measurement"
         uom: "W"
-        rule: 3
-        registers: [0x16A2, 0x16A3]
+        rule: 1
+        digits: 0
+        sensors:
+          - registers: [0x3132]
+          - registers: [0x3135]
+          - registers: [0x3138]
+          - registers: [0x313B]
         icon: "mdi:solar-power-variant"
 
       - name: "PV1 Voltage"


### PR DESCRIPTION
This fix properly identifies and combines all four PV strings into one PV Power. Before this fix, PV Power was displaying inaccurate results as seen in the screenshot below (PV1 and PV2 were the only two active strings at the time). 

<img width="306" height="283" alt="pv power not working" src="https://github.com/user-attachments/assets/577c0737-b480-4ed7-88bf-32d13a23fb24" />

