### PR TITLE
Fix Battery temperature ❘ Megarevo

### DIFF
--- a/custom_components/solarman/inverter_definitions/megarevo_r-3h.yaml
+++ b/custom_components/solarman/inverter_definitions/megarevo_r-3h.yaml
@@ -179,7 +179,7 @@ parameters:
         state_class: "measurement"
         uom: "°C"
         scale: 0.1
-        rule: 1
+        rule: 2
         registers: [0x3146]
 
       - name: "Battery Power"


### PR DESCRIPTION
Changing rule value from 1 to 2. Under 1, bat temp reads 6,552.0 C when it is -1.6 C. Changing to 2, shows proper temp. Issue appears only when temp drops below 0.