### PR TITLE
Add grid charging configurables ❘ Afore T6

### DIFF
--- a/custom_components/solarman/inverter_definitions/afore_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/afore_hybrid.yaml
@@ -547,9 +547,6 @@ parameters:
         writeback:
           register: 0x00CE
           count: 2
-          overrides:
-            - register: 0x00CE
-              value: 0x00
       
       - name: "Soft start"
         platform: switch
@@ -563,9 +560,6 @@ parameters:
         writeback:
           register: 0x00CE
           count: 2
-          overrides:
-            - register: 0x00CE
-              value: 0x00
 
       - name: "UPS mode"
         platform: switch
@@ -579,9 +573,6 @@ parameters:
         writeback:
           register: 0x00CE
           count: 2
-          overrides:
-            - register: 0x00CE
-              value: 0x00
 
       - name: "Timed AC charging"
         platform: switch
@@ -595,9 +586,6 @@ parameters:
         writeback:
           register: 0x00CE
           count: 2
-          overrides:
-            - register: 0x00CE
-              value: 0x00
       
       - name: "Timed charging"
         platform: switch
@@ -611,9 +599,6 @@ parameters:
         writeback:
           register: 0x00CE
           count: 2
-          overrides:
-            - register: 0x00CE
-              value: 0x00
       
       - name: "Timed discharging"
         platform: switch
@@ -627,9 +612,6 @@ parameters:
         writeback:
           register: 0x00CE
           count: 2
-          overrides:
-            - register: 0x00CE
-              value: 0x00
 
       - name: Battery Charge & Discharge
         platform: switch


### PR DESCRIPTION
Tested on AF9.99K-TH.

To charge a battery from the grid: 

- switch.inverter_battery_charge_discharge = on
- select.inverter_meter = "Meter"
- number.inverter_timed_charging_power > 0
- number.inverter_timed_max_charge > current battery %
- Current time within one of the timed charge windows
- switch.inverter_timed_ac_charging = on

Makes use of new writeback functionality, usable from pre-release: [v25.12.20](https://github.com/davidrapan/ha-solarman/releases/tag/v25.12.20).