### PR TITLE
Grid power factor is not configurable ❘ Deye 3P

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -2361,7 +2361,7 @@ parameters:
         registers: [0x026D]
         validation:
           min: 0
-          max: 1000
+          max: 100
         icon: "mdi:transmission-tower"
 
       # The following three (four) registers change according to the built-in and external settings


### PR DESCRIPTION
Grid power factor is not really a configurable value. V105 of the manual says it's "R", but for some reason has R/W in notes for that field. No idea why, adjusting it does nothing which is to be expected.

The inverter sometimes returns an empty string as the value, so I added the validation so it returns unknown instead of possible errors or old values.

From the old pull request I reverted back to `uom: "%"`, because it seems Home Assistant converts `class: "power_factor"` internally to the proper x.xx value so it's fine to leave as is.