### PR TITLE
fix: Allow enabling disabled entities from UI

### DIFF
--- a/custom_components/solarman/common.py
+++ b/custom_components/solarman/common.py
@@ -230,7 +230,7 @@ def preprocess_descriptions(item, group, table, code, parameters):
             if i == "registers" and source[i] and (isinstance(source[i], list) and isinstance(source[i][0], list)):
                 unwrap(source, i, parameters[CONF_MOD])
                 if not source[i]:
-                    source["disabled"] = True
+                    source["disabled"] = "force"
             elif isinstance(source[i], dict):
                 modify(source[i])
 

--- a/custom_components/solarman/parser.py
+++ b/custom_components/solarman/parser.py
@@ -70,7 +70,7 @@ class ParameterParser:
         return "name" in parameters and "rule" in parameters # and "registers" in parameters
 
     def is_enabled(self, parameters):
-        return not "disabled" in parameters
+        return not "disabled" in parameters or parameters["disabled"] != "force"
 
     def is_requestable(self, parameters):
         return self.is_valid(parameters) and self.is_enabled(parameters) and parameters["rule"] > 0


### PR DESCRIPTION
Disabled entities (`disabled:` in entity definition) are skipped completely and cannot be enabled without editing the yaml files.

This tiny fix removes the `is_enabled` check from `get_entity_descriptions` so they are added into the registry and become enablable from the UI.

Disabled entities are really not used right now, but HA recommends they should be used, and I totally agree.
https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/entity-disabled-by-default/

There are 4 disabled entities in the existing definitions, all in `solis_1p-5g.yaml`:
- Inverter ID
- Product Model
- DSP Software Version
- LCD Software Version

I did not change these to "force" which would have been equivalent to old functionality.