### PR TITLE
Fix suggested_display_precision: 0 is ignored

### DIFF
--- a/custom_components/solarman/common.py
+++ b/custom_components/solarman/common.py
@@ -303,7 +303,7 @@ def postprocess_descriptions(coordinator):
                     validation["max"] *= s
 
         # Temporary location of fix for latest HA changes regarding default precision behavior
-        if description["platform"] == "sensor" and (description.get("class") or description.get("device_class")) in ("energy", "energy_storage") and (description.get("suggested_unit_of_measurement") or description.get("unit_of_measurement") or description.get("uom")) == "kWh":
+        if description["platform"] == "sensor" and description.get('suggested_display_precision') is None and (description.get("class") or description.get("device_class")) in ("energy", "energy_storage") and (description.get("suggested_unit_of_measurement") or description.get("unit_of_measurement") or description.get("uom")) == "kWh":
             description["suggested_display_precision"] = 1
 
     _LOGGER.debug(f"postprocess_descriptions: {descriptions}")

--- a/custom_components/solarman/entity.py
+++ b/custom_components/solarman/entity.py
@@ -82,7 +82,7 @@ class SolarmanEntity(SolarmanCoordinatorEntity):
             self._attr_native_unit_of_measurement = unit_of_measurement
         if (suggested_unit_of_measurement := sensor.get("suggested_unit_of_measurement")):
             self._attr_suggested_unit_of_measurement = suggested_unit_of_measurement
-        if (suggested_display_precision := sensor.get("suggested_display_precision")):
+        if (suggested_display_precision := sensor.get("suggested_display_precision")) is not None:
             self._attr_suggested_display_precision = suggested_display_precision
         if (options := sensor.get("options")):
             self._attr_options = options


### PR DESCRIPTION
Also mentioned in a previous comment, the `suggested_display_precision` was not working properly. There was two causes:

1. `sensor.get("suggested_display_precision")` for value `0` is equal to `False` meaning it never gets applied if it's `0`.
2. The "temporary" (we all know how it always goes) fix for kWh entities fixes it to 1 and ignores anything in the description.

Both fixed in this PR.