### PR TITLE
Remove invalid validation in Internal CT power ❘ Deye 3P

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -2231,10 +2231,6 @@ parameters:
         uom: "W"
         rule: 4
         registers: [0x025F, 0x02BF]
-        validation:
-          lookup: "device_rated_power_sensor"
-          scale: 1.1
-          invalidate_all:
         icon: "mdi:transmission-tower"
 
       - name: "Grid Frequency"


### PR DESCRIPTION
The Internal Power sensor is validated to be lower than Device Rated Power * 1.1, and if it is not, the whole dataset is invalidated.
While the idea is good and works nicely in some other sensors, in this sensor it is totally wrong.

The datasheet for this inverter defines that the maximum passthrough is up to 29kW (40A) for 5-10kW models and up to 58kW (80A) for 10-25kW models. Even the 3.6-5kW LV models have up to 25kW (35A) of passthrough current.

This validation causes pretty much all data be invalidated when the battery is being charged with full power and load in the backup load port (passthru) is more than 0.1 times the rated power (more than 1kW for 10kW inverter), which is almost guaranteed to happen.

This PR removes the validation.