### PR TITLE
Add definitions for Battery Modules 7 and 8

### DIFF
--- a/custom_components/solarman/inverter_definitions/pylontech_force.yaml
+++ b/custom_components/solarman/inverter_definitions/pylontech_force.yaml
@@ -452,6 +452,53 @@ parameters:
         registers: [[5302], [], [5302]]
         icon: "mdi:thermometer"
 
+        
+  - group: Battery Module 7
+    hidden:
+    pack: 8
+    items:
+      - name: "Battery Module 7 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [[5223], [], [5223]]
+        icon: "mdi:battery"
+
+      - name: "Battery Module 7 Temperature"
+        update_interval: 10
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        registers: [[5303], [], [5303]]
+        icon: "mdi:thermometer"
+
+  - group: Battery Module 8
+    hidden:
+    pack: 8
+    items:
+      - name: "Battery Module 8 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [[5224], [], [5224]]
+        icon: "mdi:battery"
+
+      - name: "Battery Module 8 Temperature"
+        update_interval: 10
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        registers: [[5304], [], [5304]]
+        icon: "mdi:thermometer"
+
   - group: Battery Module 0 Cells
     update_interval: 60
     hidden:


### PR DESCRIPTION
Extended `pylontech_force.yaml` to include Battery Module 7 (pack 8) and Battery Module 8 (pack 9) definitions, based on register pattern extrapolation from existing modules 0-5 and gist mapping.

- Battery Module 7 Voltage: registers 5222
- Battery Module 7 Temperature: registers 5302  
- Battery Module 8 Voltage: registers 5223
- Battery Module 8 Temperature: registers 5303

Tested on Pylontech Force H1 (H48050) with 8 modules, FW version 0.1.0.1.  Cell definitions for modules 7-8 would require additional reverse engineering.