### PR TITLE
Add new scaling modifier for Battery Current ❘ Deye 1P

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
@@ -773,7 +773,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: 10
         registers: [0x00A7]
         icon: "mdi:transmission-tower"
 
@@ -783,7 +783,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: 10
         registers: [0x00A8]
         icon: "mdi:transmission-tower"
 
@@ -793,7 +793,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: 10
         registers: [0x00A9]
         icon: "mdi:transmission-tower"
         attributes: [inverse]
@@ -824,7 +824,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: 10
         registers: [0x00AA]
         icon: "mdi:transmission-tower"
 
@@ -834,7 +834,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: 10
         registers: [0x00AB]
         icon: "mdi:transmission-tower"
 
@@ -844,7 +844,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: 10
         registers: [0x00AC]
         icon: "mdi:transmission-tower"
 
@@ -874,7 +874,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: 10
         registers: [0x00B0]
 
       - name: "Load L2 Power"
@@ -883,7 +883,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: 10
         registers: [0x00B1]
 
       - name: "Load Power"
@@ -892,7 +892,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: 10
         registers: [0x00B2]
 
       - name: "Load L1 Current"

--- a/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
@@ -692,7 +692,7 @@ parameters:
         class: "current"
         state_class: "measurement"
         uom: "A"
-        scale: 0.1
+        scale: [0.01, 0.1]
         rule: 2
         registers: [0x00BF]
         icon: "mdi:current-dc"
@@ -773,7 +773,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: 10
+        scale: [1, 10] # out of date docs
         registers: [0x00A7]
         icon: "mdi:transmission-tower"
 
@@ -783,7 +783,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: 10
+        scale: [1, 10] # out of date docs
         registers: [0x00A8]
         icon: "mdi:transmission-tower"
 
@@ -793,7 +793,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: 10
+        scale: [1, 10] # out of date docs
         registers: [0x00A9]
         icon: "mdi:transmission-tower"
         attributes: [inverse]
@@ -824,7 +824,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: 10
+        scale: [1, 10] # out of date docs
         registers: [0x00AA]
         icon: "mdi:transmission-tower"
 
@@ -834,7 +834,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: 10
+        scale: [1, 10] # out of date docs
         registers: [0x00AB]
         icon: "mdi:transmission-tower"
 
@@ -844,7 +844,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: 10
+        scale: [1, 10] # out of date docs
         registers: [0x00AC]
         icon: "mdi:transmission-tower"
 
@@ -874,7 +874,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: 10
+        scale: [1, 10] # out of date docs
         registers: [0x00B0]
 
       - name: "Load L2 Power"
@@ -883,7 +883,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: 10
+        scale: [1, 10] # out of date docs
         registers: [0x00B1]
 
       - name: "Load Power"
@@ -892,7 +892,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: 10
+        scale: [1, 10] # out of date docs
         registers: [0x00B2]
 
       - name: "Backup L1 Current"

--- a/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
@@ -692,7 +692,7 @@ parameters:
         class: "current"
         state_class: "measurement"
         uom: "A"
-        scale: [0.01, 0.1]
+        scale: [0.01, 0.01, 0.1]
         rule: 2
         registers: [0x00BF]
         icon: "mdi:current-dc"
@@ -773,7 +773,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: [1, 10, 10] # out of date docs
         registers: [0x00A7]
         icon: "mdi:transmission-tower"
 
@@ -783,7 +783,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: [1, 10, 10] # out of date docs
         registers: [0x00A8]
         icon: "mdi:transmission-tower"
 
@@ -793,7 +793,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: [1, 10, 10] # out of date docs
         registers: [0x00A9]
         icon: "mdi:transmission-tower"
         attributes: [inverse]
@@ -824,7 +824,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: [1, 10, 10] # out of date docs
         registers: [0x00AA]
         icon: "mdi:transmission-tower"
 
@@ -834,7 +834,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: [1, 10, 10] # out of date docs
         registers: [0x00AB]
         icon: "mdi:transmission-tower"
 
@@ -844,7 +844,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: [1, 10, 10] # out of date docs
         registers: [0x00AC]
         icon: "mdi:transmission-tower"
 
@@ -874,7 +874,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: [1, 10, 10] # out of date docs
         registers: [0x00B0]
 
       - name: "Load L2 Power"
@@ -883,7 +883,7 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: [1, 10, 10] # out of date docs
         registers: [0x00B1]
 
       - name: "Load Power"
@@ -892,10 +892,10 @@ parameters:
         state_class: "measurement"
         uom: "W"
         rule: 2
-        scale: [1, 10] # out of date docs
+        scale: [1, 10, 10] # out of date docs
         registers: [0x00B2]
 
-      - name: "Backup L1 Current"
+      - name: "Load L1 Current"
         l: 1
         class: "current"
         state_class: "measurement"
@@ -904,7 +904,7 @@ parameters:
         rule: 2
         registers: [0x00B3]
 
-      - name: "Backup L2 Current"
+      - name: "Load L2 Current"
         l: 2
         class: "current"
         state_class: "measurement"

--- a/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
@@ -692,7 +692,7 @@ parameters:
         class: "current"
         state_class: "measurement"
         uom: "A"
-        scale: 0.01
+        scale: 0.1
         rule: 2
         registers: [0x00BF]
         icon: "mdi:current-dc"

--- a/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
@@ -895,7 +895,7 @@ parameters:
         scale: 10
         registers: [0x00B2]
 
-      - name: "Load L1 Current"
+      - name: "Backup L1 Current"
         l: 1
         class: "current"
         state_class: "measurement"
@@ -904,7 +904,7 @@ parameters:
         rule: 2
         registers: [0x00B3]
 
-      - name: "Load L2 Current"
+      - name: "Backup L2 Current"
         l: 2
         class: "current"
         state_class: "measurement"


### PR DESCRIPTION
## Summary

Fixes for `deye_hybrid.yaml` on a DEYE single-phase hybrid 10 kW inverter (`SG0*LP1`).

### Fix 1 — Battery Current scale

Changed from `scale: 0.01` to `scale: [0.01, 0.1]` so it follows the same Modifier pattern as the power sensors.

### Fix 2 — Rename Load L1/L2 Current → Backup L1/L2 Current
Not sure about this one but at least in my case (SUN-10K-SG02LP1-EU-AM3), registers 0x00B3/0x00B4 measure the backup output port current, not total house consumption. 

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)