### PR TITLE
Update deye_hybrid program * power limits

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
@@ -1828,7 +1828,7 @@ parameters:
         registers: [0x0100]
         range:
           min: 0000
-          max: 12000
+          max: 16000
         icon: mdi:sun-clock
 
       - name: "Program 2 Power"
@@ -1840,7 +1840,7 @@ parameters:
         registers: [0x0101]
         range:
           min: 0000
-          max: 12000
+          max: 16000
         icon: mdi:sun-clock
 
       - name: "Program 3 Power"
@@ -1852,7 +1852,7 @@ parameters:
         registers: [0x0102]
         range:
           min: 0000
-          max: 12000
+          max: 16000
         icon: mdi:sun-clock
 
       - name: "Program 4 Power"
@@ -1864,7 +1864,7 @@ parameters:
         registers: [0x0103]
         range:
           min: 0000
-          max: 12000
+          max: 16000
         icon: mdi:sun-clock
 
       - name: "Program 5 Power"
@@ -1876,7 +1876,7 @@ parameters:
         registers: [0x0104]
         range:
           min: 0000
-          max: 12000
+          max: 16000
         icon: mdi:sun-clock
 
       - name: "Program 6 Power"
@@ -1888,7 +1888,7 @@ parameters:
         registers: [0x0105]
         range:
           min: 0000
-          max: 12000
+          max: 16000
         icon: mdi:sun-clock
 
       - name: Program 1 Voltage


### PR DESCRIPTION
This fixes the Deye Hybrid 16kW 'Program * Power' limit by increasing it from 12000 to 16000 to match the inverter's actual capacity.