### PR TITLE
Fix signed handling for Deye Zero Export power

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
@@ -1182,13 +1182,13 @@ parameters:
         class: "power"
         state_class: "measurement"
         uom: "W"
-        rule: 1
+        rule: 2
         registers: [0x00CE]
         range:
-          min: 0
-          max: 65535
+          min: -200
+          max: 500
         configurable:
-          min: -20
+          min: -200
           max: 500
         icon: "mdi:transmission-tower"
 

--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -284,11 +284,11 @@ parameters:
         state_class: "measurement"
         uom: "W"
         scale: [1, 10]
-        rule: 1
+        rule: 2
         registers: [0x0068]
         range:
-          min: 0
-          max: 65535
+          min: [-20, 0]
+          max: 500
         configurable:
           min: [-20, 0]
           max: 500


### PR DESCRIPTION
## Summary
Fix incorrect signed/unsigned handling for Deye Zero Export power registers.

On affected Deye inverters, Zero Export power can be negative. The integration currently treats the register as unsigned, so negative values are displayed as large positive numbers such as 65515 or 65336.

This change updates the Deye profiles to parse Zero Export power as signed and corrects the single-phase hybrid configurable/range minimum to -200.

## Tested
- Reproduced the bug with negative Zero Export power values
- Verified locally on Home Assistant that the patched integration now reads and writes negative values correctly

Fixes #1047