### PR TITLE
refactor: Unify select mask to top-level key, remove display.mask

### DIFF
--- a/custom_components/solarman/inverter_definitions/afore_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/afore_hybrid.yaml
@@ -387,8 +387,7 @@ parameters:
         update_interval: 300
         platform: select
         registers: [0x00CF, 0x00CE]
-        display:
-          mask: 0x11
+        mask: 0x11
         code:
           read: 0x03
         rule: 1

--- a/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
@@ -2081,8 +2081,7 @@ parameters:
         platform: select
         rule: 1
         registers: [0x0112]
-        display:
-          mask: 0x3
+        mask: 0x3
         icon: mdi:sun-clock
         lookup:
           - key: 0x0000
@@ -2098,8 +2097,7 @@ parameters:
         platform: select
         rule: 1
         registers: [0x0113]
-        display:
-          mask: 0x3
+        mask: 0x3
         icon: mdi:sun-clock
         lookup:
           - key: 0x0000
@@ -2115,8 +2113,7 @@ parameters:
         platform: select
         rule: 1
         registers: [0x0114]
-        display:
-          mask: 0x3
+        mask: 0x3
         icon: mdi:sun-clock
         lookup:
           - key: 0x0000
@@ -2132,8 +2129,7 @@ parameters:
         platform: select
         rule: 1
         registers: [0x0115]
-        display:
-          mask: 0x3
+        mask: 0x3
         icon: mdi:sun-clock
         lookup:
           - key: 0x0000
@@ -2149,8 +2145,7 @@ parameters:
         platform: select
         rule: 1
         registers: [0x0116]
-        display:
-          mask: 0x3
+        mask: 0x3
         icon: mdi:sun-clock
         lookup:
           - key: 0x0000
@@ -2166,8 +2161,7 @@ parameters:
         platform: select
         rule: 1
         registers: [0x0117]
-        display:
-          mask: 0x3
+        mask: 0x3
         icon: mdi:sun-clock
         lookup:
           - key: 0x0000

--- a/custom_components/solarman/select.py
+++ b/custom_components/solarman/select.py
@@ -114,7 +114,7 @@ class SolarmanSelectEntity(SolarmanWritableEntity, SelectEntity):
     def __init__(self, coordinator, sensor):
         SolarmanWritableEntity.__init__(self, coordinator, sensor)
 
-        self.mask = display.get("mask") if (display := sensor.get("display")) else None
+        self.mask = sensor.get("mask")
 
         if "lookup" in sensor:
             self.dictionary = sensor["lookup"]


### PR DESCRIPTION
display.mask was introduced in Nov 2024 as a separate namespace for select entities, but it is semantically identical to the top-level mask already used by the parser for all other platforms. Having two ways to express the same concept is unnecessarily confusing.

Migrate 7 select entities (6 in deye_hybrid, 1 in afore_hybrid) from
```yaml
  display:
    mask: X
```
to
```yaml
  mask: X
```

and remove the display.mask fallback from select.py.