### PR TITLE
Adding Bexie BE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## About This Repository
+
+This is a Home Assistant custom integration for **Solarman Stick Loggers**. It enables Home Assistant to communicate with solar inverters via Solarman data loggers and compatible Modbus TCP bridges (such as ESPHome Modbus bridges, Waveshare RS485-to-ETH adapters, and Ethernet loggers).
+
+The integration is built on top of the asynchronous [pysolarmanv5](https://github.com/jmccrohan/pysolarmanv5) library and supports both the Solarman V5 protocol and raw Modbus TCP.
+
+## Bexie Hybrid Inverter — Modbus TCP at 192.168.178.134
+
+A device profile has been created at:
+`custom_components/solarman/inverter_definitions/bexie_hybrid.yaml`
+
+### Device Details
+
+| Field       | Value                  |
+|-------------|------------------------|
+| IP          | 192.168.178.134        |
+| Port        | 502                    |
+| Protocol    | Modbus TCP             |
+| Phases      | Single phase           |
+| MPPTs       | 2                      |
+| HA instance | 192.168.178.231:8123   |
+
+### Register Map (confirmed via live probe)
+
+| Block         | Range           | FC  | Contents                          |
+|---------------|-----------------|-----|-----------------------------------|
+| PV / Inverter | 0x1010–0x104C   | 03  | PV voltage, current, power, temps |
+| Grid / Load   | 0x1300–0x1338   | 03  | Grid/load power, voltage, freq    |
+| Battery       | 0x2000–0x200F   | 03  | SOC, voltage, current, power      |
+| Control (RW)  | 0x2100–0x2115   | 03/06 | Work mode, grid charge           |
+
+### Key Device-Specific Notes
+
+- **Battery Temperature**: `0x201B` (U16) — confirmed correct. `0x2001` returns 0 on this device (differs from CHINT).
+- **32-bit registers**: use inverted word order `[high_addr, low_addr]` — same as CHINT CPS-SCETL.
+- **Work Mode** (`0x2100`): writable. Currently reads `0` (Self Use). Confirmed write/readback works.
+- **Grid Charge** (`0x2115`): writable switch. Currently reads `0` (Disabled).
+- **Port 502** is only open while the inverter is active. The port closes at night / when HA holds the connection — disable HA before probing directly.
+
+### Reference
+
+- Modbus protocol document (same as CHINT): https://github.com/user-attachments/files/17295986/Hybrid.Modbus.Protocol.per.inverter.ibridi.pdf
+- Similar profile: `custom_components/solarman/inverter_definitions/chint_cps-scetl.yaml`
+
+### Tools
+
+- `tools/probe_registers.py` — reads and validates all key registers, flags implausible values. Run with:
+  ```
+  python3 tools/probe_registers.py --host 192.168.178.134
+  ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,12 +15,14 @@ A device profile has been created at:
 
 | Field       | Value                  |
 |-------------|------------------------|
-| IP          | 192.168.178.134        |
-| Port        | 502                    |
+| Host        | `mass`                 |
+| Port        | 1502                   |
 | Protocol    | Modbus TCP             |
 | Phases      | Single phase           |
 | MPPTs       | 2                      |
 | HA instance | 192.168.178.231:8123   |
+
+`mass:1502` is the current known-good address (previously documented as `192.168.178.134:502` — IP/port can drift, `mass` is the stable hostname to use going forward).
 
 ### Register Map (confirmed via live probe)
 
@@ -46,7 +48,10 @@ A device profile has been created at:
 
 ### Tools
 
-- `tools/probe_registers.py` — reads and validates all key registers, flags implausible values. Run with:
+Check this section before asking the user how to test against the real device — no need to prompt for connection details or write a one-off Modbus script.
+
+- `tools/probe_registers.py` — reads and validates all key registers on the live Bexie device, flags implausible values, and is useful for confirming/refuting a register-decode hypothesis (e.g. word order, sign, overflow) against real hardware rather than guessing from datasheet notes alone. Run with:
   ```
-  python3 tools/probe_registers.py --host 192.168.178.134
+  python3 tools/probe_registers.py --host mass --port 1502
   ```
+  (defaults to `--host 192.168.178.134 --port 502` if omitted — pass `--host mass --port 1502` explicitly, that's the current known-good address).

--- a/custom_components/solarman/common.py
+++ b/custom_components/solarman/common.py
@@ -125,7 +125,49 @@ def ensure_list_safe_len(value: list):
 def create_request(code: int, start: int, end: int):
     return { REQUEST_CODE: code, REQUEST_START: start, REQUEST_END: end, REQUEST_COUNT: end - start + 1 }
 
-async def lookup_profile(request, parameters):
+def decode_ascii(data, code, registers):
+    value = ""
+
+    for r in registers:
+        if (temp := get_addr_value(data, code, r)) is None:
+            return None
+
+        value += chr(temp >> 8) + chr(temp & 0xFF)
+
+    return value
+
+async def lookup_profile(request, parameters, directory):
+    # A profile can declare its own identification under "autodetection" (code/start/end
+    # to probe, "equals" to match the decoded ASCII value against — a single string or a
+    # list of confirmed strings, e.g. distinct model numbers on the same register layout),
+    # so adding autodetection support for a new profile is a YAML-only change. Tried before
+    # the Deye-specific probe below: an explicit, confirmed exact-string match is higher
+    # confidence than inferring a profile from a numeric code at register 0.
+    for file in sorted(Path(directory).glob("*.yaml")):
+        try:
+            if not (auto := (await yaml_open(file)).get("autodetection")):
+                continue
+        except Exception:
+            continue
+
+        try:
+            response = await request(requests = create_request(auto["code"], auto["start"], auto["end"]))
+        except TimeoutError:
+            raise
+        except Exception:
+            continue
+
+        if response and (value := decode_ascii(response, auto["code"], list(range(auto["start"], auto["end"] + 1)))) is not None:
+            # Padding byte is device-specific and unconfirmed (nulls, spaces, 0xFF, ...),
+            # so strip anything outside printable ASCII rather than assuming which one it is.
+            filtered = "".join(c for c in value if "\x20" <= c <= "\x7e").strip()
+            equals = auto["equals"]
+            if filtered in (equals if isinstance(equals, list) else (equals,)):
+                return file.name
+
+    return await lookup_profile_deye(request, parameters)
+
+async def lookup_profile_deye(request, parameters):
     if (response := await request(requests = create_request(*AUTODETECTION_REQUEST_DEYE))) and (device_type := get_addr_value(response, *AUTODETECTION_DEVICE_DEYE)):
         try:
             f, m, c = next(iter([AUTODETECTION_DEYE[i] for i in AUTODETECTION_DEYE if device_type in i]))

--- a/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
@@ -1,0 +1,394 @@
+#
+# Bexie | Hybrid Inverter | Single Phase | LV Battery | 2 MPPT
+#
+# Reference: https://github.com/user-attachments/files/17295986/Hybrid.Modbus.Protocol.per.inverter.ibridi.pdf
+# Register map closely matches CHINT CPS-SCETL pattern (same Modbus protocol document).
+#
+# Confirmed register blocks via live Modbus TCP scan (port 502) at 192.168.178.134:
+#   0x1010 - 0x104C  FC03  Real Time Data (PV / inverter)
+#   0x1300 - 0x1338  FC03  Real Time Data (grid / load)
+#   0x2000 - 0x200F  FC03  Battery data
+#
+# Notes:
+#   - 32-bit registers use inverted word order: [high_addr, low_addr] (same as CHINT)
+#   - Battery Temperature: 0x201B confirmed (0x2001 returns 0 on this device)
+#   - Battery Power: 0x200A/0x2009 pair confirmed (781W @ 52.7V / 14.81A)
+#
+
+info:
+  manufacturer: Bexie
+  model: Hybrid
+
+default:
+  update_interval: 30
+  digits: 6
+
+parameters:
+  - group: PV
+    items:
+      - name: "PV Power"
+        alt: "DC Power"
+        mppt: 1
+        description: "Combined power of all inputs"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 0.1
+        rule: 3 # unsigned 32
+        registers: [0x1049, 0x1048]
+        icon: "mdi:solar-power-variant"
+
+      - name: "PV1 Voltage"
+        alt: "DC1 Voltage"
+        mppt: 1
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x1010]
+        icon: "mdi:solar-power-variant"
+
+      - name: "PV1 Current"
+        alt: "DC1 Current"
+        mppt: 1
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 1
+        registers: [0x1011]
+        icon: "mdi:solar-power-variant"
+
+      - name: "PV1 Power"
+        alt: "DC1 Power"
+        mppt: 1
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 0.1
+        rule: 3 # unsigned 32
+        registers: [0x1013, 0x1012]
+        icon: "mdi:solar-power-variant"
+
+      - name: "PV2 Voltage"
+        alt: "DC2 Voltage"
+        mppt: 2
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x1014]
+        icon: "mdi:solar-power-variant"
+
+      - name: "PV2 Current"
+        alt: "DC2 Current"
+        mppt: 2
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 1
+        registers: [0x1015]
+        icon: "mdi:solar-power-variant"
+
+      - name: "PV2 Power"
+        alt: "DC2 Power"
+        mppt: 2
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 0.1
+        rule: 3 # unsigned 32
+        registers: [0x1017, 0x1016]
+        icon: "mdi:solar-power-variant"
+
+  - group: meter
+    items:
+      - name: "Inverter Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 1
+        rule: 2 # signed 16
+        update_interval: 90
+        registers: [0x101C]
+        icon: "mdi:thermometer"
+
+      - name: "Inverter Mode"
+        class: "enum"
+        rule: 1
+        registers: [0x101D]
+        icon: "mdi:information"
+        lookup:
+          - key: 0x0000
+            value: "Waiting"
+          - key: 0x0001
+            value: "Self-test"
+          - key: 0x0002
+            value: "On grid"
+          - key: 0x0003
+            value: "Back-up"
+          - key: 0x0004
+            value: "Flash"
+          - key: 0x0005
+            value: "Fault"
+
+  - group: energy
+    update_interval: 300
+    items:
+      - name: "Today Production"
+        alt: "Daily Production"
+        friendly_name: "Today's Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
+        scale: 1
+        rule: 3 # unsigned 32
+        registers: [0x1028, 0x1027]
+        icon: "mdi:solar-power"
+
+      - name: "Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        rule: 3
+        icon: "mdi:solar-power"
+        sensors:
+          - registers: [0x1022, 0x1021]
+          - registers: [0x104C]
+            scale: 0.001
+        validation:
+          min: 0.001
+          dev: 100
+          invalidate_all: 2
+
+      - name: "Today Energy Import"
+        alt: "Today Energy Bought"
+        description: "Energy imported from the grid today"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
+        scale: 10
+        rule: 3
+        registers: [0x1333, 0x1332]
+        icon: "mdi:transmission-tower-export"
+
+      - name: "Today Energy Export"
+        alt: "Today Energy Sold"
+        description: "Energy exported to the grid today"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
+        scale: 10
+        rule: 3
+        registers: [0x1335, 0x1334]
+        icon: "mdi:transmission-tower-import"
+
+      - name: "Today Load Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
+        scale: 10
+        rule: 3
+        registers: [0x1337, 0x1336]
+
+      - name: "Total Energy Import"
+        alt: "Total Energy Bought"
+        description: "Total energy imported from the grid"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.01
+        digits: 2
+        rule: 3
+        registers: [0x1307, 0x1306]
+        icon: "mdi:transmission-tower-import"
+        validation:
+          min: 0.01
+
+      - name: "Total Energy Export"
+        alt: "Total Energy Sold"
+        description: "Total energy exported to the grid"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.01
+        digits: 2
+        rule: 3
+        registers: [0x1309, 0x1308]
+        icon: "mdi:transmission-tower-export"
+        validation:
+          min: 0.01
+
+      - name: "Total Load Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.01
+        rule: 3
+        registers: [0x1311, 0x1310]
+        validation:
+          min: 0.01
+
+  - group: grid
+    items:
+      - name: "Grid Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        update_interval: 90
+        registers: [0x131A]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid Frequency"
+        class: "frequency"
+        state_class: "measurement"
+        uom: "Hz"
+        scale: 0.01
+        rule: 1
+        update_interval: 90
+        registers: [0x1338]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 0.1
+        rule: 4 # signed 32
+        registers: [0x1301, 0x1300]
+        icon: "mdi:transmission-tower"
+
+  - group: load
+    items:
+      - name: "Load Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 0.1
+        rule: 4 # signed 32
+        registers: [0x130B, 0x130A]
+        icon: "mdi:home-lightning-bolt"
+
+  - group: control
+    update_interval: 60
+    items:
+      - name: "Work Mode"
+        platform: select
+        rule: 1
+        registers: [0x2100]
+        icon: "mdi:solar-power"
+        lookup:
+          - key: 0x0000
+            value: "Self Use"
+          - key: 0x0001
+            value: "Feed-in Priority"
+          - key: 0x0002
+            value: "Time-based Control"
+          - key: 0x0003
+            value: "Back-up"
+
+      - name: "Grid Charge"
+        platform: switch
+        rule: 1
+        registers: [0x2115]
+        icon: "mdi:transmission-tower-export"
+        value:
+          on: 0x0001
+          off: 0x0000
+
+      - name: "Grid Charge End SOC"
+        platform: number
+        class: "battery"
+        uom: "%"
+        rule: 1
+        registers: [0x2117]
+        icon: "mdi:battery-charging"
+        configurable:
+          min: 0
+          max: 100
+          step: 1
+          mode: box
+        range:
+          min: 0
+          max: 100
+
+  - group: battery
+    items:
+      - name: "Battery SOC"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [0x2000]
+        icon: "mdi:battery"
+
+      - name: "Battery Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 1
+        rule: 1 # unsigned 16 — 0x201B confirmed on this device (0x2001 returns 0)
+        update_interval: 90
+        registers: [0x201B]
+        icon: "mdi:thermometer"
+
+      - name: "Battery Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x2006]
+        icon: "mdi:voltage-dc"
+
+      - name: "Battery Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 4 # signed 32 — negative = charging, positive = discharging
+        registers: [0x2008, 0x2007]
+        icon: "mdi:current-dc"
+
+      - name: "Battery Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 0.1
+        rule: 2 # signed 16 — negative = charging, positive = discharging
+        registers: [0x200A]
+        icon: "mdi:battery-charging"
+
+  - group: battery_energy
+    update_interval: 300
+    items:
+      - name: "Today Battery Charge"
+        alt: "Daily Battery Charge"
+        friendly_name: "Today's Battery Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
+        scale: 10
+        rule: 3
+        registers: [0x200C, 0x200B]
+        icon: "mdi:battery-plus"
+        range:
+          max: 0xFFFFFFF9
+
+      - name: "Today Battery Discharge"
+        alt: "Daily Battery Discharge"
+        friendly_name: "Today's Battery Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "Wh"
+        scale: 10
+        rule: 3
+        registers: [0x2010, 0x200F]
+        icon: "mdi:battery-minus"
+        range:
+          max: 0xFFFFFFF9

--- a/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
@@ -26,7 +26,9 @@
 #      omitted here — that register overlaps the start of Master Software
 #      Version and decodes to garbage when nibble-split. CHINT's "EMS
 #      firmware" fields are named "CSB" here per the Bexie app's own naming
-#      for the same registers.
+#      for the same registers. "Device" (0x1A00+) decodes to "BE6KW-1PH" on
+#      this unit — the SKU string, not a manufacturer name; do not assume
+#      other Bexie models share this prefix.
 #   8. No EPS group — not available on this model.
 #   9. No fault registers — 0x101E–0x1020 and 0x2013 not yet confirmed on this device.
 #  10. Default update_interval is 30 s (CHINT uses 60 s).
@@ -35,6 +37,16 @@
 info:
   manufacturer: Bexie
   model: Hybrid
+
+# Lets "Auto" profile selection identify this device: reads the "Device" ASCII block
+# below (0x1A00-0x1A0F) and matches on the exact SKU string confirmed on real hardware.
+# CHINT CPS-SCETL shares this same register block but reports a different string, so an
+# exact match (not a prefix/substring match) is required to tell the two apart.
+autodetection:
+  code: 0x03
+  start: 0x1A00
+  end: 0x1A0F
+  equals: "BE6KW-1PH"
 
 default:
   update_interval: 30

--- a/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
@@ -21,7 +21,12 @@
 #   5. Writable control registers added (0x2100+): Work Mode (select),
 #      Grid Charge (switch), Grid Charge End SOC (number). Not present in CHINT profile.
 #   6. Inverter Mode sensor added (0x101D). Not present in CHINT profile.
-#   7. No device info block (0x1A00+) — not confirmed available on this device.
+#   7. Device info block at 0x1A00+ confirmed on this device, offsets match
+#      CHINT exactly. "Device Protocol Version" (CHINT: 0x1A1C, rule 7) is
+#      omitted here — that register overlaps the start of Master Software
+#      Version and decodes to garbage when nibble-split. CHINT's "EMS
+#      firmware" fields are named "CSB" here per the Bexie app's own naming
+#      for the same registers.
 #   8. No EPS group — not available on this model.
 #   9. No fault registers — 0x101E–0x1020 and 0x2013 not yet confirmed on this device.
 #  10. Default update_interval is 30 s (CHINT uses 60 s).
@@ -36,6 +41,150 @@ default:
   digits: 6
 
 parameters:
+  - group: info
+    update_interval: 3600
+    items:
+      - name: "Device"
+        rule: 5 # ASCII String
+        registers:
+          [
+            0x1A00,
+            0x1A01,
+            0x1A02,
+            0x1A03,
+            0x1A04,
+            0x1A05,
+            0x1A06,
+            0x1A07,
+            0x1A08,
+            0x1A09,
+            0x1A0A,
+            0x1A0B,
+            0x1A0C,
+            0x1A0D,
+            0x1A0E,
+            0x1A0F,
+          ]
+        icon: "mdi:information"
+        attributes:
+          [
+            "Device Serial Number",
+            "Master Software Version",
+            "Master Software Build Date",
+            "Slave Firmware Version",
+            "Slave Firmware Build Date",
+            "Device MPPTs",
+            "Device Rated Voltage",
+            "Device Rated Frequency",
+            "Device Rated Power",
+            "Device Phases",
+            "Production Type",
+            "CSB Firmware Version",
+            "CSB Firmware Build Date",
+            "DCDC Firmware Version",
+            "DCDC Firmware Build Date",
+          ]
+
+      - name: "Device Serial Number"
+        attribute:
+        rule: 5 # ASCII String
+        registers:
+          [0x1A10, 0x1A11, 0x1A12, 0x1A13, 0x1A14, 0x1A15, 0x1A16, 0x1A17]
+
+      - name: "Master Software Version"
+        attribute:
+        rule: 5 # ASCII String
+        registers: [0x1A1C, 0x1A1D, 0x1A1E]
+
+      - name: "Master Software Build Date"
+        attribute:
+        rule: 5 # ASCII String
+        registers: [0x1A23, 0x1A24, 0x1A25]
+
+      - name: "Slave Firmware Version"
+        attribute:
+        rule: 5 # ASCII String
+        registers: [0x1A26, 0x1A27, 0x1A28]
+
+      - name: "Slave Firmware Build Date"
+        attribute:
+        rule: 5 # ASCII String
+        registers: [0x1A2D, 0x1A2E, 0x1A2F]
+
+      - name: "Device MPPTs"
+        attribute:
+        rule: 1 # unsigned data
+        registers: [0x1A3B]
+
+      - name: "Device Rated Voltage"
+        attribute:
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x1A44]
+
+      - name: "Device Rated Frequency"
+        attribute:
+        class: "frequency"
+        state_class: "measurement"
+        uom: "Hz"
+        scale: 0.01
+        rule: 1
+        registers: [0x1A45]
+
+      - name: "Device Rated Power"
+        attribute:
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x1A46]
+
+      - name: "Device Phases"
+        attribute:
+        rule: 1
+        registers: [0x1A48]
+
+      - name: "Production Type"
+        attribute:
+        class: "enum"
+        rule: 1
+        registers: [0x1A5A]
+        lookup:
+          - key: 0x0000
+            value: "On grid"
+          - key: [0x0001]
+            value: "AC couple no smart load"
+          - key: [0x0002]
+            value: "Hybrid no smart load"
+          - key: [0x0003]
+            value: "Hybrid with smart load"
+          - key: [0x0004]
+            value: "AC couple with smart load"
+
+      - name: "CSB Firmware Version"
+        attribute:
+        rule: 5 # ASCII String
+        registers: [0x1A60, 0x1A61, 0x1A62]
+
+      - name: "CSB Firmware Build Date"
+        attribute:
+        rule: 5 # ASCII String
+        registers: [0x1A67, 0x1A68, 0x1A69]
+
+      - name: "DCDC Firmware Version"
+        attribute:
+        rule: 5 # ASCII String
+        registers: [0x1A6F, 0x1A70, 0x1A71]
+
+      - name: "DCDC Firmware Build Date"
+        attribute:
+        rule: 5 # ASCII String
+        registers: [0x1A76, 0x1A77, 0x1A78]
+
   - group: PV
     items:
       - name: "PV Power"

--- a/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
@@ -9,15 +9,14 @@
 # Notes:
 #   - 32-bit registers use inverted word order: [high_addr, low_addr] (same as CHINT)
 #   - Battery Temperature: 0x201B confirmed (0x2001 returns 0 on this device)
-#   - Battery Power: 0x200A/0x2009 pair confirmed (781W @ 52.7V / 14.81A) —
-#     but that data point only confirms the low word (0x200A) since the
-#     magnitude was small. Reading 0x200A alone as signed 16 (rule 2) is known
-#     to overflow above 3276.7W, which flips the sign and misreports high-power
-#     discharge as charging (seen under Feed-in Priority, where discharge can
-#     exceed typical Self Use draw). Changed to read the signed 32-bit pair
-#     (rule 4); this assumes 0x2009 is a genuine high word including sign
-#     extension while charging — not yet confirmed against a real charging
-#     sample, so re-check if charging readings look wrong after this change.
+#   - Battery Power: 0x200A/0x2009 pair confirmed (781W @ 52.7V / 14.81A).
+#     Reading 0x200A alone as signed 16 (rule 2) overflows above 3276.7W,
+#     flipping the sign and misreporting high-power discharge as charging —
+#     reproduced live under Feed-in Priority (5397W discharge, confirmed via
+#     Battery Current x Voltage, read back as -1156.6W under the old rule 2
+#     definition; 0x2009 read 0x0000, the expected high word for a value that
+#     fits in the low 16 bits). Fixed by reading the signed 32-bit pair
+#     (rule 4), matching Battery Current's pattern.
 #
 # Differences from CHINT CPS-SCETL:
 #   1. Single phase only — no L1/L2/L3 output, grid current, or per-phase load entities.

--- a/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
@@ -1,18 +1,30 @@
 #
 # Bexie | Hybrid Inverter | Single Phase | LV Battery | 2 MPPT
 #
+# https://bexieenergy.com/product/be3-6-6kw-1ph/
+#
 # Reference: https://github.com/user-attachments/files/17295986/Hybrid.Modbus.Protocol.per.inverter.ibridi.pdf
 # Register map closely matches CHINT CPS-SCETL pattern (same Modbus protocol document).
-#
-# Confirmed register blocks via live Modbus TCP scan (port 502) at 192.168.178.134:
-#   0x1010 - 0x104C  FC03  Real Time Data (PV / inverter)
-#   0x1300 - 0x1338  FC03  Real Time Data (grid / load)
-#   0x2000 - 0x200F  FC03  Battery data
 #
 # Notes:
 #   - 32-bit registers use inverted word order: [high_addr, low_addr] (same as CHINT)
 #   - Battery Temperature: 0x201B confirmed (0x2001 returns 0 on this device)
 #   - Battery Power: 0x200A/0x2009 pair confirmed (781W @ 52.7V / 14.81A)
+#
+# Differences from CHINT CPS-SCETL:
+#   1. Single phase only — no L1/L2/L3 output, grid current, or per-phase load entities.
+#   2. 2 MPPTs only — CHINT supports up to 9; PV3–PV9 entries are absent here.
+#   3. Battery Temperature uses 0x201B (unsigned 16, rule 1); CHINT uses 0x2001
+#      (signed 16, rule 2). Register 0x2001 returns 0 on this device.
+#   4. Battery Power is a single signed 16-bit register at 0x200A (rule 2);
+#      CHINT reads an unsigned 32-bit pair [0x200A, 0x2009] (rule 3).
+#   5. Writable control registers added (0x2100+): Work Mode (select),
+#      Grid Charge (switch), Grid Charge End SOC (number). Not present in CHINT profile.
+#   6. Inverter Mode sensor added (0x101D). Not present in CHINT profile.
+#   7. No device info block (0x1A00+) — not confirmed available on this device.
+#   8. No EPS group — not available on this model.
+#   9. No fault registers — 0x101E–0x1020 and 0x2013 not yet confirmed on this device.
+#  10. Default update_interval is 30 s (CHINT uses 60 s).
 #
 
 info:

--- a/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/bexie_hybrid.yaml
@@ -9,15 +9,24 @@
 # Notes:
 #   - 32-bit registers use inverted word order: [high_addr, low_addr] (same as CHINT)
 #   - Battery Temperature: 0x201B confirmed (0x2001 returns 0 on this device)
-#   - Battery Power: 0x200A/0x2009 pair confirmed (781W @ 52.7V / 14.81A)
+#   - Battery Power: 0x200A/0x2009 pair confirmed (781W @ 52.7V / 14.81A) —
+#     but that data point only confirms the low word (0x200A) since the
+#     magnitude was small. Reading 0x200A alone as signed 16 (rule 2) is known
+#     to overflow above 3276.7W, which flips the sign and misreports high-power
+#     discharge as charging (seen under Feed-in Priority, where discharge can
+#     exceed typical Self Use draw). Changed to read the signed 32-bit pair
+#     (rule 4); this assumes 0x2009 is a genuine high word including sign
+#     extension while charging — not yet confirmed against a real charging
+#     sample, so re-check if charging readings look wrong after this change.
 #
 # Differences from CHINT CPS-SCETL:
 #   1. Single phase only — no L1/L2/L3 output, grid current, or per-phase load entities.
 #   2. 2 MPPTs only — CHINT supports up to 9; PV3–PV9 entries are absent here.
 #   3. Battery Temperature uses 0x201B (unsigned 16, rule 1); CHINT uses 0x2001
 #      (signed 16, rule 2). Register 0x2001 returns 0 on this device.
-#   4. Battery Power is a single signed 16-bit register at 0x200A (rule 2);
-#      CHINT reads an unsigned 32-bit pair [0x200A, 0x2009] (rule 3).
+#   4. Battery Power reads the same [0x200A, 0x2009] pair as CHINT, but as
+#      signed 32-bit (rule 4) rather than CHINT's unsigned 32-bit (rule 3) —
+#      needed so discharge (positive) and charge (negative) both read correctly.
 #   5. Writable control registers added (0x2100+): Work Mode (select),
 #      Grid Charge (switch), Grid Charge End SOC (number). Not present in CHINT profile.
 #   6. Inverter Mode sensor added (0x101D). Not present in CHINT profile.
@@ -533,8 +542,8 @@ parameters:
         state_class: "measurement"
         uom: "W"
         scale: 0.1
-        rule: 2 # signed 16 — negative = charging, positive = discharging
-        registers: [0x200A]
+        rule: 4 # signed 32 — negative = charging, positive = discharging
+        registers: [0x200A, 0x2009]
         icon: "mdi:battery-charging"
 
   - group: battery_energy

--- a/custom_components/solarman/parser.py
+++ b/custom_components/solarman/parser.py
@@ -325,14 +325,8 @@ class ParameterParser:
         self.set_state(key, get_number(value, get_or_def(definition, DIGITS, self._digits)))
 
     def try_parse_ascii(self, data, definition):
-        code = get_code(definition, "read")
-        value = ""
-
-        for r in definition["registers"]:
-            if (temp := get_addr_value(data, code, r)) is None:
-                return
-
-            value += chr(temp >> 8) + chr(temp & 0xFF)
+        if (value := decode_ascii(data, get_code(definition, "read"), definition["registers"])) is None:
+            return
 
         self.set_state(definition["key"], value)
 

--- a/custom_components/solarman/provider.py
+++ b/custom_components/solarman/provider.py
@@ -133,6 +133,6 @@ class ProfileProvider:
         return self.parser.info
 
     async def init(self, request: Callable[[int, dict], Awaitable[dict]] | None = None):
-        if (f := await lookup_profile(request, self.parameters) if self.auto else self.filename) and f != DEFAULT_[CONF_LOOKUP_FILE] and (n := process_profile(f, self.parameters)):
+        if (f := await lookup_profile(request, self.parameters, self.config.directory) if self.auto else self.filename) and f != DEFAULT_[CONF_LOOKUP_FILE] and (n := process_profile(f, self.parameters)):
             self.parser = await ParameterParser().init(self.config.directory, n, self.parameters)
         return self

--- a/tools/probe_registers.py
+++ b/tools/probe_registers.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Probe Modbus TCP registers on a hybrid inverter and check for plausible values.
+Usage: python3 tools/probe_registers.py --host 192.168.178.134
+"""
+
+import os
+import yaml
+import struct
+import argparse
+from pymodbus.client import ModbusTcpClient
+
+PROFILE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "custom_components", "solarman",
+    "inverter_definitions", "bexie_hybrid.yaml",
+)
+
+HOST = "192.168.178.134"
+PORT = 502
+UNIT = 1
+
+# Registers to probe based on the Hybrid Modbus Protocol PDF
+# (address, count, type, scale, unit, description)
+REGISTERS = [
+    # --- PV ---
+    (0x1010, 1, "U16", 0.1,   "V",   "PV1 Voltage"),
+    (0x1011, 1, "U16", 0.01,  "A",   "PV1 Current"),
+    (0x1012, 2, "U32", 0.1,   "W",   "MPPT1 Power"),
+    (0x1014, 1, "U16", 0.1,   "V",   "PV2 Voltage"),
+    (0x1015, 1, "U16", 0.01,  "A",   "PV2 Current"),
+    (0x1016, 2, "U32", 0.1,   "W",   "MPPT2 Power"),
+    (0x1048, 2, "U32", 0.1,   "W",   "PV Total Power"),
+    # --- Inverter ---
+    (0x101C, 1, "S16", 1.0,   "°C",  "Inverter Temperature"),
+    (0x101D, 1, "U16", 1.0,   "",    "Inverter Mode"),
+    (0x1021, 2, "U32", 1.0,   "kWh", "Total Energy"),
+    (0x1027, 2, "U32", 1.0,   "Wh",  "Today Energy"),
+    (0x1037, 2, "S32", 0.1,   "W",   "Active Power"),
+    # --- Grid ---
+    (0x1300, 2, "S32", 0.1,   "W",   "Grid Power (Phase R)"),
+    (0x131A, 1, "U16", 0.1,   "V",   "Grid Voltage L1"),
+    (0x1338, 1, "U16", 0.01,  "Hz",  "Grid Frequency"),
+    (0x1306, 2, "U32", 10.0,  "Wh",  "Grid Accumulated Import"),
+    (0x1308, 2, "U32", 10.0,  "Wh",  "Grid Accumulated Export"),
+    (0x1332, 2, "U32", 10.0,  "Wh",  "Today Import Energy"),
+    (0x1334, 2, "U32", 10.0,  "Wh",  "Today Export Energy"),
+    # --- Load ---
+    (0x130A, 2, "S32", 0.1,   "W",   "Load Power (Phase R)"),
+    (0x1310, 2, "U32", 10.0,  "Wh",  "Load Accumulated Energy"),
+    (0x1336, 2, "U32", 10.0,  "Wh",  "Today Load Energy"),
+    # --- Battery ---
+    (0x2000, 1, "U16", 1.0,   "%",   "Battery SOC"),
+    (0x2001, 1, "S16", 1.0,   "°C",  "Battery Temperature (PDF: 0x2001)"),
+    (0x201B, 1, "U16", 1.0,   "°C",  "Battery Temperature (YAML: 0x201B)"),
+    (0x2006, 1, "U16", 0.1,   "V",   "Battery Voltage"),
+    (0x2007, 2, "S32", 0.01,  "A",   "Battery Current"),
+    (0x2009, 2, "U32", 0.1,   "W",   "Battery Power (PDF: 0x2009, U32)"),
+    (0x200A, 1, "S16", 0.1,   "W",   "Battery Power (YAML: 0x200A, S16)"),
+    (0x200B, 2, "U32", 10.0,  "Wh",  "Battery Daily Charge Energy"),
+    (0x200F, 2, "U32", 10.0,  "Wh",  "Battery Daily Discharge Energy"),
+]
+
+
+def decode(registers, rtype):
+    if rtype == "U16":
+        return registers[0]
+    elif rtype == "S16":
+        v = registers[0]
+        return v if v < 0x8000 else v - 0x10000
+    elif rtype == "U32":
+        return (registers[0] << 16) | registers[1]
+    elif rtype == "S32":
+        v = (registers[0] << 16) | registers[1]
+        return v if v < 0x80000000 else v - 0x100000000
+    return None
+
+
+def plausible(value, rtype, unit, description):
+    """Rough sanity checks — flag obviously bad values."""
+    flags = []
+    if rtype in ("U16", "U32") and value == 0xFFFF:
+        flags.append("MAX_U16 (likely N/A)")
+    if rtype == "U32" and value == 0xFFFFFFFF:
+        flags.append("MAX_U32 (likely N/A)")
+    if "Voltage" in description and unit == "V":
+        if not (0 < value < 1500):
+            flags.append(f"out of range for voltage ({value}V)")
+    if "Current" in description and unit == "A":
+        if not (-200 < value < 200):
+            flags.append(f"out of range for current ({value}A)")
+    if "Frequency" in description:
+        if not (45 < value < 65):
+            flags.append(f"out of range for freq ({value}Hz)")
+    if "Temperature" in description:
+        if not (-20 < value < 120):
+            flags.append(f"out of range for temp ({value}°C)")
+    if "SOC" in description:
+        if not (0 <= value <= 100):
+            flags.append(f"out of range for SOC ({value}%)")
+    return flags
+
+
+def check_autodetection(client, profile_path=PROFILE_PATH):
+    """Probe the block this profile's "autodetection" declares and check it decodes
+    to the expected string, using the exact decode/normalize logic in common.py's
+    lookup_profile (ASCII pairs, then strip to printable-ASCII range and strip())."""
+    with open(profile_path) as f:
+        profile = yaml.safe_load(f)
+
+    auto = profile.get("autodetection")
+    if not auto:
+        print(f"No 'autodetection' block in {profile_path}")
+        return
+
+    code, start, end, equals = auto["code"], auto["start"], auto["end"], auto["equals"]
+    expected = equals if isinstance(equals, list) else [equals]
+    count = end - start + 1
+
+    print(f"\nAutodetection probe: fc{code} @ 0x{start:04X}-0x{end:04X} ({count} regs)")
+    rr = client.read_holding_registers(start, count=count)
+    if rr.isError():
+        print(f"  ERROR reading registers: {rr}")
+        return
+
+    print(f"  Raw registers: {[f'0x{r:04X}' for r in rr.registers]}")
+
+    decoded = "".join(chr(r >> 8) + chr(r & 0xFF) for r in rr.registers)
+    print(f"  Decoded (raw):  {decoded!r}")
+
+    filtered = "".join(c for c in decoded if "\x20" <= c <= "\x7e").strip()
+    print(f"  Decoded (filtered): {filtered!r}")
+
+    if filtered in expected:
+        print(f"  MATCH against {expected!r}")
+    else:
+        print(f"  NO MATCH against {expected!r} -- update 'equals' in {profile_path} to {filtered!r}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Probe hybrid inverter Modbus registers")
+    parser.add_argument("--host", default=HOST)
+    parser.add_argument("--port", default=PORT, type=int)
+    parser.add_argument("--unit", default=UNIT, type=int)
+    args = parser.parse_args()
+
+    client = ModbusTcpClient(args.host, port=args.port)
+    if not client.connect():
+        print(f"ERROR: Cannot connect to {args.host}:{args.port}")
+        return
+
+    print(f"\nConnected to {args.host}:{args.port} (unit {args.unit})\n")
+
+    check_autodetection(client)
+
+    print(f"\n{'Address':<10} {'Description':<42} {'Raw':>10}  {'Value':>12}  {'Notes'}")
+    print("-" * 100)
+
+    for addr, count, rtype, scale, unit, desc in REGISTERS:
+        try:
+            rr = client.read_holding_registers(addr, count=count)
+            if rr.isError():
+                print(f"0x{addr:04X}     {desc:<42} ERROR: {rr}")
+                continue
+            raw = decode(rr.registers, rtype)
+            value = raw * scale
+            flags = plausible(value, rtype, unit, desc)
+            flag_str = "  ⚠ " + ", ".join(flags) if flags else ""
+            print(f"0x{addr:04X}     {desc:<42} {raw:>10}  {value:>10.2f} {unit:<4}{flag_str}")
+        except Exception as e:
+            print(f"0x{addr:04X}     {desc:<42} EXCEPTION: {e}")
+
+    client.close()
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
ModBus over TCP - directly to the inverter

https://bexieenergy.com/product/be3-6-6kw-1ph/

CHINT CPS-SCETL vs Bexie Hybrid differences:
1. Phase count: CHINT is three-phase; Bexie is single-phase
   - CHINT has output L1/L2/L3 voltage/current/power, grid L1/L2/L3 voltage/current, load L1/L2/L3 power/voltage/current, Internal CT1/CT2/CT3 power, EPS L1/L2/L3 power
   - Bexie only has single Grid Voltage, single Grid Power, and single Load Power
2. MPPT count: CHINT supports up to 9 MPPTs while Bexie has just 2
3. Battery Temperature register: CHINT reads from 0x2001 as a signed 16-bit value, but Bexie uses 0x201B as unsigned 16-bit — and 0x2001 returns 0 on Bexie
4. Battery Power: The two systems use different register rules and addresses for this metric — CHINT uses a 32-bit unsigned value across two registers, while Bexie uses a single 16-bit signed register with a different rule
5. Device info block: CHINT has a complete device info group spanning 0x1A00–0x1A78, but Bexie doesn't have this
6. EPS group: CHINT includes a full Emergency Power Supply group that Bexie lacks
7. Fault registers: CHINT tracks Battery Fault and Inverter Fault states, but Bexie doesn't expose these
8. Control registers: Bexie has Work Mode, Grid Charge, and Grid Charge End SOC controls that CHINT doesn't support
9. update_interval: CHINT defaults to 60 seconds while Bexie defaults to 30 seconds
10. Grid Power: Both use the same registers but CHINT labels it "Internal CT1 Power" while Bexie calls it "Grid Power"
11. Load Power: CHINT hides this metric while Bexie exposes it, though they're at the same register addresses
12. PV items: The PV group structure differs — CHINT lists PV1-PV9 Power separately, while Bexie includes Voltage and Current directly in the PV group with only 2 MPPTs
13. DC Temperature: CHINT marks this as hidden and calls it "DC Temperature"; Bexie shows it as "Inverter Temperature"
14. Inverter Mode: Bexie includes this field but CHINT's profile doesn't
15. Today Production validation: CHINT has validation rules set; Bexie doesn't include this
16. Total Load Consumption scale: CHINT applies a 0.01 scale factor
, and Bexie uses the same
17. Battery Current rule: Both use rule 4 for signed 32-bit values