### PR TITLE
feat: Add AC power, battery management, and diagnostic sensors for Hinen

### DIFF
--- a/custom_components/solarman/entity.py
+++ b/custom_components/solarman/entity.py
@@ -72,7 +72,7 @@ class SolarmanEntity(SolarmanCoordinatorEntity):
         self._attr_device_class = sensor.get("class") or sensor.get("device_class")
         self._attr_translation_key = sensor.get("translation_key") or slugify(self._attr_name)
         self._attr_unique_id = slugify(self.coordinator.config_entry.entry_id, self._attr_key)
-        self._attr_entity_category = sensor.get("category") or sensor.get("entity_category")
+        self._attr_entity_category = EntityCategory(sensor.get("category") or sensor.get("entity_category")) if sensor.get("category") or sensor.get("entity_category") else None
         self._attr_entity_registry_enabled_default = not "disabled" in sensor
         self._attr_entity_registry_visible_default = not "hidden" in sensor
         self._attr_friendly_name = sensor.get(CONF_FRIENDLY_NAME)

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -858,12 +858,98 @@ parameters:
         rule: 1
         registers: [147]
         icon: "mdi:alert-outline"
-        description: "Inverter main fault code (0 = no fault)"
+        description: "Inverter main fault/warning code (0 = no fault)"
         lookup:
           - key: 0
             value: "No Fault"
+          - key: 108
+            value: "Fault: NTC Temperature too high"
+          - key: 109
+            value: "Fault: Bus voltage abnormal"
+          - key: 110
+            value: "Fault: Communication fault"
+          - key: 200
+            value: "Fault: No AC Connection"
+          - key: 201
+            value: "Fault: AC V Outrange"
+          - key: 202
+            value: "Fault: AC F Outrange"
+          - key: 205
+            value: "Fault: CT LN Reversed"
+          - key: 300
+            value: "Fault: EPS OP Short Fault"
+          - key: 302
+            value: "Fault: Off-grid output voltage is too low"
+          - key: 303
+            value: "Fault: Off-grid output voltage is too High"
+          - key: 401
+            value: "Fault: The DC input voltage is exceeding the maximum tolerable value"
+          - key: 500
+            value: "Fault: BMS Communication fault"
+          - key: 502
+            value: "Fault: Battery voltage low"
+          - key: 503
+            value: "Fault: Battery Voltage High"
+          - key: 504
+            value: "Fault: Battery temperature out of specified range for charge or discharge"
+          - key: 505
+            value: "Fault: Battery terminals reversed"
+          - key: 506
+            value: "Fault: Battery terminal open (only for lithium battery)"
+          - key: 1100
+            value: "Warning: Fan function abnormal"
+          - key: 1101
+            value: "Warning: Meter abnormal"
+          - key: 1102
+            value: "Warning: Optimizer and inverter communication is abnormal"
+          - key: 1103
+            value: "Warning: Optimizer and inverter communication is abnormal"
+          - key: 1104
+            value: "Warning: Bus voltage Low"
+          - key: 1200
+            value: "Warning: No Utility"
+          - key: 1201
+            value: "Warning: Grid voltage outrange"
+          - key: 1202
+            value: "Warning: Grid frequency outrange"
+          - key: 1204
+            value: "Warning: CT Open"
+          - key: 1205
+            value: "Warning: SP-CT L N line reversed or Ground fail"
+          - key: 1206
+            value: "Warning: Communication fault, M didn't receive SP-CT data"
+          - key: 1302
+            value: "Warning: Off-grid output voltage is too High"
+          - key: 1303
+            value: "Warning: Off-grid output voltage is too low"
+          - key: 1304
+            value: "Warning: EPS OP OverLord Warning"
+          - key: 1404
+            value: "Warning: Dryconnect function abnormal"
+          - key: 1406
+            value: "Warning: PV Reversed"
+          - key: 1501
+            value: "Warning: Battery terminal open (only for lithium battery)"
+          - key: 1502
+            value: "Warning: Lead-acid battery temperature sensor was open"
+          - key: 1503
+            value: "Warning: Battery temperature outrange"
+          - key: 1504
+            value: "Warning: Lithium battery Over Load warning"
+          - key: 1505
+            value: "Warning: Lithium battery only charge warning"
+          - key: 1506
+            value: "Warning: Lithium battery need charge warning"
+          - key: 1507
+            value: "Warning: Lithium battery charge full warning"
+          - key: 1508
+            value: "Warning: Lithium battery disable charge for bus High warning"
+          - key: 1509
+            value: "Warning: Lithium battery disable discharge for bus High warning"
+          - key: 1510
+            value: "Warning: Temperature sensor connection is abnormal"
           - key: default
-            value: "Fault"
+            value: "Unknown"
 
       - name: "Software Sub Version"
         entity_category: "diagnostic"
@@ -920,9 +1006,16 @@ parameters:
 
       - name: "Fault Subcode"
         entity_category: "diagnostic"
+        class: "enum"
         rule: 1
         registers: [148]
-        description: "Inverter sub-fault code"
+        icon: "mdi:alert-outline"
+        description: "Inverter sub-fault code (0 = none)"
+        lookup:
+          - key: 0
+            value: "None"
+          - key: default
+            value: "Unknown"
 
       - name: "ISO Resistance"
         entity_category: "diagnostic"

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -261,6 +261,7 @@ parameters:
         description: "Total AC apparent power of the inverter"
 
       - name: "Grid L1 Voltage"
+        entity_category: "diagnostic"
         l: 1
         class: "voltage"
         state_class: "measurement"
@@ -271,6 +272,7 @@ parameters:
         icon: "mdi:transmission-tower"
 
       - name: "Grid L1 Current"
+        entity_category: "diagnostic"
         l: 1
         class: "current"
         state_class: "measurement"
@@ -281,6 +283,7 @@ parameters:
         icon: "mdi:transmission-tower"
 
       - name: "Grid L1 Active Power"
+        entity_category: "diagnostic"
         l: 1
         class: "power"
         state_class: "measurement"
@@ -292,6 +295,7 @@ parameters:
         description: "R-phase active power"
 
       - name: "Grid L1 Reactive Power"
+        entity_category: "diagnostic"
         l: 1
         class: "power"
         state_class: "measurement"
@@ -303,6 +307,7 @@ parameters:
         description: "R-phase reactive power"
 
       - name: "Grid L2 Voltage"
+        entity_category: "diagnostic"
         l: 2
         class: "voltage"
         state_class: "measurement"
@@ -313,6 +318,7 @@ parameters:
         icon: "mdi:transmission-tower"
 
       - name: "Grid L2 Current"
+        entity_category: "diagnostic"
         l: 2
         class: "current"
         state_class: "measurement"
@@ -323,6 +329,7 @@ parameters:
         icon: "mdi:transmission-tower"
 
       - name: "Grid L2 Apparent Power"
+        entity_category: "diagnostic"
         l: 2
         class: "power"
         state_class: "measurement"
@@ -334,6 +341,7 @@ parameters:
         description: "S-phase apparent power"
 
       - name: "Grid L2 Active Power"
+        entity_category: "diagnostic"
         l: 2
         class: "power"
         state_class: "measurement"
@@ -345,6 +353,7 @@ parameters:
         description: "S-phase active power"
 
       - name: "Grid L2 Reactive Power"
+        entity_category: "diagnostic"
         l: 2
         class: "power"
         state_class: "measurement"
@@ -356,6 +365,7 @@ parameters:
         description: "S-phase reactive power"
 
       - name: "Grid L3 Voltage"
+        entity_category: "diagnostic"
         l: 3
         class: "voltage"
         state_class: "measurement"
@@ -366,6 +376,7 @@ parameters:
         icon: "mdi:transmission-tower"
 
       - name: "Grid L3 Current"
+        entity_category: "diagnostic"
         l: 3
         class: "current"
         state_class: "measurement"
@@ -376,6 +387,7 @@ parameters:
         icon: "mdi:transmission-tower"
 
       - name: "Grid L3 Apparent Power"
+        entity_category: "diagnostic"
         l: 3
         class: "power"
         state_class: "measurement"
@@ -387,6 +399,7 @@ parameters:
         description: "T-phase apparent power"
 
       - name: "Grid L3 Active Power"
+        entity_category: "diagnostic"
         l: 3
         class: "power"
         state_class: "measurement"
@@ -398,6 +411,7 @@ parameters:
         description: "T-phase active power"
 
       - name: "Grid L3 Reactive Power"
+        entity_category: "diagnostic"
         l: 3
         class: "power"
         state_class: "measurement"
@@ -409,6 +423,7 @@ parameters:
         description: "T-phase reactive power"
 
       - name: "Grid Voltage RS"
+        entity_category: "diagnostic"
         class: "voltage"
         state_class: "measurement"
         uom: "V"
@@ -419,6 +434,7 @@ parameters:
         description: "R-S line voltage"
 
       - name: "Grid Voltage ST"
+        entity_category: "diagnostic"
         class: "voltage"
         state_class: "measurement"
         uom: "V"
@@ -429,6 +445,7 @@ parameters:
         description: "S-T line voltage"
 
       - name: "Grid Voltage TR"
+        entity_category: "diagnostic"
         class: "voltage"
         state_class: "measurement"
         uom: "V"
@@ -439,6 +456,7 @@ parameters:
         description: "T-R line voltage"
 
       - name: "CT1 Current"
+        entity_category: "diagnostic"
         class: "current"
         state_class: "measurement"
         uom: "A"
@@ -448,6 +466,7 @@ parameters:
         description: "CT1 sampling current for external meter"
 
       - name: "CT2 Current"
+        entity_category: "diagnostic"
         class: "current"
         state_class: "measurement"
         uom: "A"
@@ -457,6 +476,7 @@ parameters:
         description: "CT2 sampling current for external meter"
 
       - name: "CT Status"
+        entity_category: "diagnostic"
         class: "enum"
         rule: 1
         registers: [119]
@@ -543,6 +563,7 @@ parameters:
         description: "Battery current measured by the BMS"
 
       - name: "BMS Max Charge Current"
+        entity_category: "diagnostic"
         state_class: "measurement"
         uom: "A"
         scale: .1
@@ -551,6 +572,7 @@ parameters:
         description: "Maximum charging current allowed by the BMS"
 
       - name: "BMS Max Discharge Current"
+        entity_category: "diagnostic"
         state_class: "measurement"
         uom: "A"
         scale: .1
@@ -559,6 +581,7 @@ parameters:
         description: "Maximum discharging current allowed by the BMS"
 
       - name: "BMS Gauge Remaining"
+        entity_category: "diagnostic"
         state_class: "measurement"
         uom: "Wh"
         rule: 1
@@ -566,6 +589,7 @@ parameters:
         description: "BMS reported remaining capacity"
 
       - name: "BMS Gauge Full Charge Capacity"
+        entity_category: "diagnostic"
         state_class: "measurement"
         uom: "Wh"
         rule: 1
@@ -573,6 +597,7 @@ parameters:
         description: "BMS reported full charge capacity"
 
       - name: "BMS Cycle Count"
+        entity_category: "diagnostic"
         state_class: "measurement"
         rule: 1
         registers: [173]
@@ -609,20 +634,24 @@ parameters:
     update_interval: 3600
     items:
       - name: Battery Software Version
+        entity_category: "diagnostic"
         rule: 1
         registers: [170]
 
       - name: "Master DSP Version"
+        entity_category: "diagnostic"
         rule: 1
         registers: [341]
         description: "Master DSP firmware version (major * 100 + minor)"
 
       - name: "Slave DSP Version"
+        entity_category: "diagnostic"
         rule: 1
         registers: [342]
         description: "Slave DSP firmware version (major * 100 + minor)"
 
       - name: "Total Working Time"
+        entity_category: "diagnostic"
         state_class: "total_increasing"
         uom: "s"
         scale: .5
@@ -634,6 +663,7 @@ parameters:
     update_interval: 30
     items:
       - name: "IPM Temperature"
+        entity_category: "diagnostic"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -643,6 +673,7 @@ parameters:
         description: "Internal intelligent power module temperature"
 
       - name: "LLC Temperature"
+        entity_category: "diagnostic"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -652,6 +683,7 @@ parameters:
         description: "Inductor-Inductor-Capacitor resonant converter radiator temperature"
 
       - name: "Fan Speed"
+        entity_category: "diagnostic"
         state_class: "measurement"
         rule: 1
         registers: [135]
@@ -659,6 +691,7 @@ parameters:
         description: "Internal cooling fan speed"
 
       - name: "Bus1 Voltage"
+        entity_category: "diagnostic"
         class: "voltage"
         state_class: "measurement"
         uom: "V"
@@ -668,6 +701,7 @@ parameters:
         description: "DC bus 1 internal voltage"
 
       - name: "Bus2 Voltage"
+        entity_category: "diagnostic"
         class: "voltage"
         state_class: "measurement"
         uom: "V"
@@ -677,6 +711,7 @@ parameters:
         description: "DC bus 2 internal voltage"
 
       - name: "Fault Maincode"
+        entity_category: "diagnostic"
         class: "enum"
         rule: 1
         registers: [147]
@@ -689,11 +724,13 @@ parameters:
             value: "Fault"
 
       - name: "Software Sub Version"
+        entity_category: "diagnostic"
         rule: 1
         registers: [121]
         description: "DSP sub-version number"
 
       - name: "MCU Temperature"
+        entity_category: "diagnostic"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -703,6 +740,7 @@ parameters:
         description: "Monitor board chip temperature"
 
       - name: "Ambient Temperature"
+        entity_category: "diagnostic"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -712,6 +750,7 @@ parameters:
         description: "Monitor board environment temperature"
 
       - name: "BatVolt DSP"
+        entity_category: "diagnostic"
         state_class: "measurement"
         uom: "V"
         scale: .1
@@ -720,6 +759,7 @@ parameters:
         description: "Battery voltage sampled by the inverter"
 
       - name: "LLC Voltage"
+        entity_category: "diagnostic"
         state_class: "measurement"
         uom: "V"
         scale: .1
@@ -728,6 +768,7 @@ parameters:
         description: "LLC resonant converter voltage"
 
       - name: "BatPackVolt"
+        entity_category: "diagnostic"
         state_class: "measurement"
         uom: "V"
         scale: .1
@@ -736,11 +777,13 @@ parameters:
         description: "Battery pack voltage"
 
       - name: "Fault Subcode"
+        entity_category: "diagnostic"
         rule: 1
         registers: [148]
         description: "Inverter sub-fault code"
 
       - name: "ISO Resistance"
+        entity_category: "diagnostic"
         state_class: "measurement"
         uom: "k\u03A9"
         rule: 1
@@ -748,6 +791,7 @@ parameters:
         description: "Insulation resistance value"
 
       - name: "GFCI"
+        entity_category: "diagnostic"
         state_class: "measurement"
         uom: "mA"
         rule: 2
@@ -755,6 +799,7 @@ parameters:
         description: "Ground fault circuit interrupter current"
 
       - name: "Derating Mode Flag"
+        entity_category: "diagnostic"
         class: "enum"
         rule: 1
         registers: [153]
@@ -766,6 +811,7 @@ parameters:
             value: "Derating"
 
       - name: "Power Cos Flag"
+        entity_category: "diagnostic"
         class: "enum"
         rule: 1
         registers: [154]

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -749,7 +749,6 @@ parameters:
     update_interval: 300
     items:
       - name: "Energy Pattern"
-        platform: "select"
         rule: 1
         registers: [125]
         icon: mdi:battery-sync
@@ -761,8 +760,7 @@ parameters:
           - key: 2
             value: "Grid"
             
-      - name: "Battery Control Mode"
-        platform: "select"
+      - name: "Battery Type"
         rule: 1
         registers: [126]
         icon: "mdi:battery"

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -241,7 +241,7 @@ parameters:
         description: "AC power drawn from the grid to charge the battery"
 
       - name: "Reactive Power"
-        class: "power"
+        class: "reactive_power"
         state_class: "measurement"
         uom: "var"
         scale: .1
@@ -251,7 +251,7 @@ parameters:
         description: "Total AC reactive power of the inverter"
 
       - name: "Apparent Power"
-        class: "power"
+        class: "apparent_power"
         state_class: "measurement"
         uom: "VA"
         scale: .1
@@ -297,7 +297,7 @@ parameters:
       - name: "Grid L1 Reactive Power"
         entity_category: "diagnostic"
         l: 1
-        class: "power"
+        class: "reactive_power"
         state_class: "measurement"
         uom: "var"
         scale: .1
@@ -331,7 +331,7 @@ parameters:
       - name: "Grid L2 Apparent Power"
         entity_category: "diagnostic"
         l: 2
-        class: "power"
+        class: "apparent_power"
         state_class: "measurement"
         uom: "VA"
         scale: .1
@@ -355,7 +355,7 @@ parameters:
       - name: "Grid L2 Reactive Power"
         entity_category: "diagnostic"
         l: 2
-        class: "power"
+        class: "reactive_power"
         state_class: "measurement"
         uom: "var"
         scale: .1
@@ -389,7 +389,7 @@ parameters:
       - name: "Grid L3 Apparent Power"
         entity_category: "diagnostic"
         l: 3
-        class: "power"
+        class: "apparent_power"
         state_class: "measurement"
         uom: "VA"
         scale: .1
@@ -413,7 +413,7 @@ parameters:
       - name: "Grid L3 Reactive Power"
         entity_category: "diagnostic"
         l: 3
-        class: "power"
+        class: "reactive_power"
         state_class: "measurement"
         uom: "var"
         scale: .1

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -767,6 +767,8 @@ parameters:
         rule: 1
         registers: [140]
         icon: "mdi:battery"
+        code: 0x03
+        update_interval: 5
 
       - name: "Battery Type"
         rule: 1

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -759,7 +759,15 @@ parameters:
             value: "Battery"
           - key: 2
             value: "Grid"
-            
+
+      - name: "Load First Stop SOC"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        rule: 1
+        registers: [140]
+        icon: "mdi:battery"
+
       - name: "Battery Type"
         rule: 1
         registers: [126]

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -609,6 +609,7 @@ parameters:
       - name: "BMS Status"
         entity_category: "diagnostic"
         state_class: "measurement"
+        rule: 1
         registers: [155]
         description: "Battery management system status"
 
@@ -617,6 +618,7 @@ parameters:
         state_class: "measurement"
         uom: "%"
         scale: .01
+        rule: 1
         registers: [162]
         description: "BMS-reported state of charge (0.01 resolution)"
 
@@ -626,6 +628,7 @@ parameters:
         state_class: "measurement"
         uom: "V"
         scale: .1
+        rule: 1
         registers: [163]
         description: "BMS-reported battery voltage"
 
@@ -641,6 +644,7 @@ parameters:
 
       - name: "BMS Hardware Version"
         entity_category: "diagnostic"
+        rule: 1
         registers: [171]
         description: "BMS hardware version number"
 
@@ -649,6 +653,7 @@ parameters:
         state_class: "measurement"
         uom: "V"
         scale: .001
+        rule: 1
         registers: [172]
         description: "Single battery voltage difference within the pack"
 
@@ -657,16 +662,19 @@ parameters:
         state_class: "measurement"
         uom: "V"
         scale: .1
+        rule: 1
         registers: [175]
         description: "BMS constant voltage (CV) setpoint"
 
       - name: "BMS Info"
         entity_category: "diagnostic"
+        rule: 1
         registers: [176]
         description: "BMS information flags"
 
       - name: "Pack Info"
         entity_category: "diagnostic"
+        rule: 1
         registers: [177]
         description: "Battery pack information flags"
 
@@ -675,6 +683,7 @@ parameters:
         state_class: "measurement"
         uom: "V"
         scale: .001
+        rule: 1
         registers: [178]
         description: "Maximum voltage among all cells in the battery"
 
@@ -683,18 +692,21 @@ parameters:
         state_class: "measurement"
         uom: "V"
         scale: .001
+        rule: 1
         registers: [179]
         description: "Minimum voltage among all cells in the battery"
 
       - name: "Module Count"
         entity_category: "diagnostic"
         state_class: "measurement"
+        rule: 1
         registers: [180]
         description: "Number of battery modules in parallel"
 
       - name: "Cell Count"
         entity_category: "diagnostic"
         state_class: "measurement"
+        rule: 1
         registers: [181]
         description: "Number of cells per module"
 
@@ -704,6 +716,7 @@ parameters:
         state_class: "measurement"
         uom: "°C"
         scale: .1
+        rule: 2
         registers: [184]
         description: "Maximum temperature among all cells"
 
@@ -713,6 +726,7 @@ parameters:
         state_class: "measurement"
         uom: "°C"
         scale: .1
+        rule: 2
         registers: [185]
         description: "Minimum temperature among all cells"
 

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -213,6 +213,33 @@ parameters:
         rule: 2
         registers: [77, 76]
 
+      - name: "Grid Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: .1
+        rule: 2
+        registers: [26, 25]
+        icon: "mdi:transmission-tower"
+        description: "Total AC active power of the inverter"
+
+      - name: "Power Factor"
+        state_class: "measurement"
+        scale: .0001
+        offset: 10000
+        rule: 1
+        registers: [57]
+        description: "Power factor offset from 10000 (formula: PF = (raw - 10000) / 10000)"
+
+      - name: "AC Charge Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: .1
+        rule: 1
+        registers: [107, 106]
+        description: "AC power drawn from the grid to charge the battery"
+
   - group: Battery
     update_interval: 5
     items:
@@ -268,6 +295,62 @@ parameters:
         registers: [105, 104]
         icon: mdi:battery-plus
 
+      - name: "Battery Combined Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: .1
+        rule: 2
+        registers: [150, 149]
+        icon: "mdi:battery"
+        description: "Combined battery power (positive = charge, negative = discharge)"
+
+      - name: "Battery Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: .1
+        rule: 2
+        registers: [164]
+        icon: "mdi:current-dc"
+        description: "Battery current measured by the BMS"
+
+      - name: "BMS Max Charge Current"
+        state_class: "measurement"
+        uom: "A"
+        scale: .1
+        rule: 1
+        registers: [166]
+        description: "Maximum charging current allowed by the BMS"
+
+      - name: "BMS Max Discharge Current"
+        state_class: "measurement"
+        uom: "A"
+        scale: .1
+        rule: 1
+        registers: [167]
+        description: "Maximum discharging current allowed by the BMS"
+
+      - name: "BMS Gauge Remaining"
+        state_class: "measurement"
+        uom: "Wh"
+        rule: 1
+        registers: [168]
+        description: "BMS reported remaining capacity"
+
+      - name: "BMS Gauge Full Charge Capacity"
+        state_class: "measurement"
+        uom: "Wh"
+        rule: 1
+        registers: [169]
+        description: "BMS reported full charge capacity"
+
+      - name: "BMS Cycle Count"
+        state_class: "measurement"
+        rule: 1
+        registers: [173]
+        description: "Number of battery charge/discharge cycles"
+
   - group: Settings
     update_interval: 300
     items:
@@ -301,6 +384,74 @@ parameters:
       - name: Battery Software Version
         rule: 1
         registers: [170]
+
+      - name: "Master DSP Version"
+        rule: 1
+        registers: [341]
+        description: "Master DSP firmware version (major * 100 + minor)"
+
+      - name: "Slave DSP Version"
+        rule: 1
+        registers: [342]
+        description: "Slave DSP firmware version (major * 100 + minor)"
+
+  - group: Diagnostics
+    update_interval: 30
+    items:
+      - name: "IPM Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: .1
+        rule: 2
+        registers: [133]
+        description: "Internal intelligent power module temperature"
+
+      - name: "LLC Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: .1
+        rule: 2
+        registers: [134]
+        description: "Inductor-Inductor-Capacitor resonant converter radiator temperature"
+
+      - name: "Fan Speed"
+        state_class: "measurement"
+        rule: 1
+        registers: [135]
+        icon: "mdi:fan"
+        description: "Internal cooling fan speed"
+
+      - name: "Bus1 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [130]
+        description: "DC bus 1 internal voltage"
+
+      - name: "Bus2 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [131]
+        description: "DC bus 2 internal voltage"
+
+      - name: "Fault Maincode"
+        class: "enum"
+        rule: 1
+        registers: [147]
+        icon: "mdi:alert-outline"
+        description: "Inverter main fault code (0 = no fault)"
+        lookup:
+          - key: 0
+            value: "No Fault"
+          - key: default
+            value: "Fault"
 
   - group: Energy
     update_interval: 30
@@ -390,7 +541,7 @@ parameters:
 
       - name: "Today Energy Export"
         alt: Daily Energy Sold
-        descripton: Today's energy exported/returned to the grid
+        description: "Energy exported to the grid today"
         class: "energy"
         state_class: "total_increasing"
         uom: "kWh"

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -62,6 +62,16 @@ parameters:
         registers: [340, 339]
         icon: "mdi:solar-power-variant"
 
+      - name: "Total PV Input Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: .1
+        rule: 1
+        registers: [2, 1]
+        entity_category: "diagnostic"
+        icon: "mdi:solar-power-variant"
+
       - name: PV1 Voltage
         alt: DC1 Voltage
         class: "voltage"
@@ -87,6 +97,7 @@ parameters:
         class: "power"
         state_class: "measurement"
         uom: "W"
+        scale: .1
         rule: 1
         registers: [7, 6]
         icon: "mdi:solar-power-variant"
@@ -112,10 +123,11 @@ parameters:
         icon: "mdi:solar-power-variant"
 
       - name: PV2 Power
-        alt: DC1 Power
+        alt: DC2 Power
         class: "power"
         state_class: "measurement"
         uom: "W"
+        scale: .1
         rule: 1
         registers: [12, 11]
         icon: "mdi:solar-power-variant"
@@ -145,6 +157,7 @@ parameters:
         class: "power"
         state_class: "measurement"
         uom: "W"
+        scale: .1
         rule: 1
         registers: [17, 16]
         icon: "mdi:solar-power-variant"
@@ -174,6 +187,7 @@ parameters:
         class: "power"
         state_class: "measurement"
         uom: "W"
+        scale: .1
         rule: 1
         registers: [22, 21]
         icon: "mdi:solar-power-variant"
@@ -259,28 +273,6 @@ parameters:
         registers: [24, 23]
         icon: "mdi:transmission-tower"
         description: "Total AC apparent power of the inverter"
-
-      - name: "Grid L1 Voltage"
-        entity_category: "diagnostic"
-        l: 1
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: .1
-        rule: 1
-        registers: [31]
-        icon: "mdi:transmission-tower"
-
-      - name: "Grid L1 Current"
-        entity_category: "diagnostic"
-        l: 1
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: .1
-        rule: 2
-        registers: [32]
-        icon: "mdi:transmission-tower"
 
       - name: "Grid L1 Active Power"
         entity_category: "diagnostic"

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -603,6 +603,119 @@ parameters:
         registers: [173]
         description: "Number of battery charge/discharge cycles"
 
+  - group: Battery Diagnostics
+    update_interval: 60
+    items:
+      - name: "BMS Status"
+        entity_category: "diagnostic"
+        state_class: "measurement"
+        registers: [155]
+        description: "Battery management system status"
+
+      - name: "BMS SOC"
+        entity_category: "diagnostic"
+        state_class: "measurement"
+        uom: "%"
+        scale: .01
+        registers: [162]
+        description: "BMS-reported state of charge (0.01 resolution)"
+
+      - name: "BMS Voltage"
+        entity_category: "diagnostic"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        registers: [163]
+        description: "BMS-reported battery voltage"
+
+      - name: "BMS Temperature"
+        entity_category: "diagnostic"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: .1
+        rule: 2
+        registers: [165]
+        description: "BMS-reported battery temperature"
+
+      - name: "BMS Hardware Version"
+        entity_category: "diagnostic"
+        registers: [171]
+        description: "BMS hardware version number"
+
+      - name: "BMS Delta Voltage"
+        entity_category: "diagnostic"
+        state_class: "measurement"
+        uom: "V"
+        scale: .001
+        registers: [172]
+        description: "Single battery voltage difference within the pack"
+
+      - name: "BMS Constant Voltage"
+        entity_category: "diagnostic"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        registers: [175]
+        description: "BMS constant voltage (CV) setpoint"
+
+      - name: "BMS Info"
+        entity_category: "diagnostic"
+        registers: [176]
+        description: "BMS information flags"
+
+      - name: "Pack Info"
+        entity_category: "diagnostic"
+        registers: [177]
+        description: "Battery pack information flags"
+
+      - name: "Max Cell Voltage"
+        entity_category: "diagnostic"
+        state_class: "measurement"
+        uom: "V"
+        scale: .001
+        registers: [178]
+        description: "Maximum voltage among all cells in the battery"
+
+      - name: "Min Cell Voltage"
+        entity_category: "diagnostic"
+        state_class: "measurement"
+        uom: "V"
+        scale: .001
+        registers: [179]
+        description: "Minimum voltage among all cells in the battery"
+
+      - name: "Module Count"
+        entity_category: "diagnostic"
+        state_class: "measurement"
+        registers: [180]
+        description: "Number of battery modules in parallel"
+
+      - name: "Cell Count"
+        entity_category: "diagnostic"
+        state_class: "measurement"
+        registers: [181]
+        description: "Number of cells per module"
+
+      - name: "Max Cell Temperature"
+        entity_category: "diagnostic"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: .1
+        registers: [184]
+        description: "Maximum temperature among all cells"
+
+      - name: "Min Cell Temperature"
+        entity_category: "diagnostic"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: .1
+        registers: [185]
+        description: "Minimum temperature among all cells"
+
   - group: Settings
     update_interval: 300
     items:
@@ -1220,6 +1333,111 @@ parameters:
           dev: 100
           invalidate_all:
         description: "Monthly energy imported from the grid"
+
+      - name: "AC Today Production"
+        alt: "AC Daily Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [251, 250]
+        icon: "mdi:solar-power"
+        description: "Daily AC-side energy production"
+
+      - name: "AC Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [253, 252]
+        icon: "mdi:solar-power"
+        description: "Total AC-side energy production"
+
+      - name: "AC Charge Today Energy"
+        alt: "AC Charge Daily Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [285, 284]
+        icon: "mdi:transmission-tower-export"
+        description: "Daily AC energy used to charge the battery from the grid"
+
+      - name: "AC Charge Total Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [287, 286]
+        icon: "mdi:transmission-tower-export"
+        description: "Total AC energy used to charge the battery from the grid"
+
+      - name: "Extra Today Energy"
+        alt: "Extra Daily Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [289, 288]
+        icon: "mdi:flash"
+        description: "Daily extra power from inverter to loads"
+
+      - name: "Extra Total Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [291, 290]
+        icon: "mdi:flash"
+        description: "Total extra power from inverter to loads"
+
+      - name: "System Today Energy"
+        alt: "System Daily Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [293, 292]
+        icon: "mdi:sine-wave"
+        description: "Daily system energy generation"
+
+      - name: "System Total Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [295, 294]
+        icon: "mdi:sine-wave"
+        description: "Total system energy generation"
+
+      - name: "Self Consumption Today"
+        alt: "Self Consumption Daily"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [297, 296]
+        icon: "mdi:home-lightning-bolt"
+        description: "Daily self-consumed PV energy (generated and used locally)"
+
+      - name: "Self Consumption Total"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [299, 298]
+        icon: "mdi:home-lightning-bolt"
+        description: "Total self-consumed PV energy (generated and used locally)"
 
       - name: Today Losses
         alt: Daily Losses

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -395,6 +395,14 @@ parameters:
         registers: [342]
         description: "Slave DSP firmware version (major * 100 + minor)"
 
+      - name: "Total Working Time"
+        state_class: "total_increasing"
+        uom: "s"
+        scale: .5
+        rule: 1
+        registers: [255, 254]
+        description: "Total inverter operating time in seconds (register value × 0.5)"
+
   - group: Diagnostics
     update_interval: 30
     items:
@@ -482,6 +490,102 @@ parameters:
           min: .1
           dev: 100
           invalidate_all: 2
+
+      - name: "PV1 Today Production"
+        alt: "PV1 Daily Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [257, 256]
+        icon: "mdi:solar-power"
+        description: "Daily energy production from PV1 MPPT input"
+        validation:
+          dev: 100
+          invalidate_all:
+
+      - name: "PV1 Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [259, 258]
+        icon: "mdi:solar-power"
+        description: "Total energy production from PV1 MPPT input"
+
+      - name: "PV2 Today Production"
+        alt: "PV2 Daily Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [261, 260]
+        icon: "mdi:solar-power"
+        description: "Daily energy production from PV2 MPPT input"
+        validation:
+          dev: 100
+          invalidate_all:
+
+      - name: "PV2 Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [263, 262]
+        icon: "mdi:solar-power"
+        description: "Total energy production from PV2 MPPT input"
+
+      - name: "PV3 Today Production"
+        alt: "PV3 Daily Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [265, 264]
+        icon: "mdi:solar-power"
+        description: "Daily energy production from PV3 MPPT input"
+        validation:
+          dev: 100
+          invalidate_all:
+
+      - name: "PV3 Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [267, 266]
+        icon: "mdi:solar-power"
+        description: "Total energy production from PV3 MPPT input"
+
+      - name: "PV4 Today Production"
+        alt: "PV4 Daily Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [269, 268]
+        icon: "mdi:solar-power"
+        description: "Daily energy production from PV4 MPPT input"
+        validation:
+          dev: 100
+          invalidate_all:
+
+      - name: "PV4 Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [271, 270]
+        icon: "mdi:solar-power"
+        description: "Total energy production from PV4 MPPT input"
 
       - name: "Today Battery Charge"
         alt: "Battery Daily Charging Energy"

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -491,6 +491,35 @@ parameters:
           dev: 100
           invalidate_all: 2
 
+      - name: "PV Year Production"
+        alt: "PV Annual Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [351, 350]
+        icon: "mdi:solar-power"
+        validation:
+          min: .1
+          dev: 100
+          invalidate_all: 2
+        description: "Annual PV energy production"
+
+      - name: "PV Month Production"
+        alt: "PV Monthly Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [353, 352]
+        icon: "mdi:solar-power"
+        validation:
+          dev: 100
+          invalidate_all:
+        description: "Monthly PV energy production"
+
       - name: "PV1 Today Production"
         alt: "PV1 Daily Production"
         class: "energy"
@@ -606,6 +635,35 @@ parameters:
         registers: [279, 278]
         icon: "mdi:battery-plus"
 
+      - name: "Battery Charge Year"
+        alt: "Battery Charge Annual"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [367, 366]
+        icon: "mdi:battery-plus"
+        validation:
+          min: .1
+          dev: 100
+          invalidate_all: 2
+        description: "Annual battery charge energy"
+
+      - name: "Battery Charge Month"
+        alt: "Battery Charge Monthly"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [369, 368]
+        icon: "mdi:battery-plus"
+        validation:
+          dev: 100
+          invalidate_all:
+        description: "Monthly battery charge energy"
+
       - name: "Today Battery Discharge"
         alt: "Battery Daily Discharging Energy"
         class: "energy"
@@ -625,6 +683,35 @@ parameters:
         registers: [283, 282]
         icon: "mdi:battery-minus"
 
+      - name: "Battery Discharge Year"
+        alt: "Battery Discharge Annual"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [371, 370]
+        icon: "mdi:battery-minus"
+        validation:
+          min: .1
+          dev: 100
+          invalidate_all: 2
+        description: "Annual battery discharge energy"
+
+      - name: "Battery Discharge Month"
+        alt: "Battery Discharge Monthly"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [373, 372]
+        icon: "mdi:battery-minus"
+        validation:
+          dev: 100
+          invalidate_all:
+        description: "Monthly battery discharge energy"
+
       - name: "Today Load Consumption"
         alt: Daily Load Consumption
         friendly_name: Today's Energy Consumption
@@ -642,6 +729,33 @@ parameters:
         scale: .1
         rule: 2
         registers: [303, 302]
+
+      - name: "Load Year Consumption"
+        alt: "Load Annual Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [355, 354]
+        validation:
+          min: .1
+          dev: 100
+          invalidate_all: 2
+        description: "Annual load consumption"
+
+      - name: "Load Month Consumption"
+        alt: "Load Monthly Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [357, 356]
+        validation:
+          dev: 100
+          invalidate_all:
+        description: "Monthly load consumption"
 
       - name: "Today Energy Export"
         alt: Daily Energy Sold
@@ -665,6 +779,35 @@ parameters:
         registers: [307, 306]
         icon: mdi:transmission-tower-import
 
+      - name: "Export Year Energy"
+        alt: "Export Annual Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [359, 358]
+        icon: "mdi:transmission-tower-import"
+        validation:
+          min: .1
+          dev: 100
+          invalidate_all: 2
+        description: "Annual energy exported to the grid"
+
+      - name: "Export Month Energy"
+        alt: "Export Monthly Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [361, 360]
+        icon: "mdi:transmission-tower-import"
+        validation:
+          dev: 100
+          invalidate_all:
+        description: "Monthly energy exported to the grid"
+
       - name: "Today Energy Import"
         alt: Daily Energy Bought
         friendly_name: Today's Energy Import
@@ -687,6 +830,35 @@ parameters:
         rule: 2
         registers: [311, 310]
         icon: mdi:transmission-tower-export
+
+      - name: "Import Year Energy"
+        alt: "Import Annual Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [363, 362]
+        icon: "mdi:transmission-tower-export"
+        validation:
+          min: .1
+          dev: 100
+          invalidate_all: 2
+        description: "Annual energy imported from the grid"
+
+      - name: "Import Month Energy"
+        alt: "Import Monthly Energy"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: .1
+        rule: 2
+        registers: [365, 364]
+        icon: "mdi:transmission-tower-export"
+        validation:
+          dev: 100
+          invalidate_all:
+        description: "Monthly energy imported from the grid"
 
       - name: Today Losses
         alt: Daily Losses

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -608,6 +608,7 @@ parameters:
     items:
       - name: "BMS Status"
         entity_category: "diagnostic"
+        hidden:
         state_class: "measurement"
         rule: 1
         registers: [155]
@@ -615,6 +616,7 @@ parameters:
 
       - name: "BMS SOC"
         entity_category: "diagnostic"
+        hidden:
         state_class: "measurement"
         uom: "%"
         scale: .01
@@ -624,6 +626,7 @@ parameters:
 
       - name: "BMS Voltage"
         entity_category: "diagnostic"
+        hidden:
         class: "voltage"
         state_class: "measurement"
         uom: "V"
@@ -634,6 +637,7 @@ parameters:
 
       - name: "BMS Temperature"
         entity_category: "diagnostic"
+        hidden:
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -644,12 +648,14 @@ parameters:
 
       - name: "BMS Hardware Version"
         entity_category: "diagnostic"
+        hidden:
         rule: 1
         registers: [171]
         description: "BMS hardware version number"
 
       - name: "BMS Delta Voltage"
         entity_category: "diagnostic"
+        hidden:
         state_class: "measurement"
         uom: "V"
         scale: .001
@@ -659,6 +665,7 @@ parameters:
 
       - name: "BMS Constant Voltage"
         entity_category: "diagnostic"
+        hidden:
         state_class: "measurement"
         uom: "V"
         scale: .1
@@ -668,18 +675,21 @@ parameters:
 
       - name: "BMS Info"
         entity_category: "diagnostic"
+        hidden:
         rule: 1
         registers: [176]
         description: "BMS information flags"
 
       - name: "Pack Info"
         entity_category: "diagnostic"
+        hidden:
         rule: 1
         registers: [177]
         description: "Battery pack information flags"
 
       - name: "Max Cell Voltage"
         entity_category: "diagnostic"
+        hidden:
         state_class: "measurement"
         uom: "V"
         scale: .001
@@ -689,6 +699,7 @@ parameters:
 
       - name: "Min Cell Voltage"
         entity_category: "diagnostic"
+        hidden:
         state_class: "measurement"
         uom: "V"
         scale: .001
@@ -698,6 +709,7 @@ parameters:
 
       - name: "Module Count"
         entity_category: "diagnostic"
+        hidden:
         state_class: "measurement"
         rule: 1
         registers: [180]
@@ -705,6 +717,7 @@ parameters:
 
       - name: "Cell Count"
         entity_category: "diagnostic"
+        hidden:
         state_class: "measurement"
         rule: 1
         registers: [181]
@@ -712,6 +725,7 @@ parameters:
 
       - name: "Max Cell Temperature"
         entity_category: "diagnostic"
+        hidden:
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -722,6 +736,7 @@ parameters:
 
       - name: "Min Cell Temperature"
         entity_category: "diagnostic"
+        hidden:
         class: "temperature"
         state_class: "measurement"
         uom: "°C"

--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -240,6 +240,233 @@ parameters:
         registers: [107, 106]
         description: "AC power drawn from the grid to charge the battery"
 
+      - name: "Reactive Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "var"
+        scale: .1
+        rule: 2
+        registers: [28, 27]
+        icon: "mdi:transmission-tower"
+        description: "Total AC reactive power of the inverter"
+
+      - name: "Apparent Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "VA"
+        scale: .1
+        rule: 2
+        registers: [24, 23]
+        icon: "mdi:transmission-tower"
+        description: "Total AC apparent power of the inverter"
+
+      - name: "Grid L1 Voltage"
+        l: 1
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [31]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid L1 Current"
+        l: 1
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: .1
+        rule: 2
+        registers: [32]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid L1 Active Power"
+        l: 1
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: .1
+        rule: 2
+        registers: [34, 33]
+        icon: "mdi:transmission-tower"
+        description: "R-phase active power"
+
+      - name: "Grid L1 Reactive Power"
+        l: 1
+        class: "power"
+        state_class: "measurement"
+        uom: "var"
+        scale: .1
+        rule: 2
+        registers: [36, 35]
+        icon: "mdi:transmission-tower"
+        description: "R-phase reactive power"
+
+      - name: "Grid L2 Voltage"
+        l: 2
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [37]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid L2 Current"
+        l: 2
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: .1
+        rule: 2
+        registers: [38]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid L2 Apparent Power"
+        l: 2
+        class: "power"
+        state_class: "measurement"
+        uom: "VA"
+        scale: .1
+        rule: 2
+        registers: [40, 39]
+        icon: "mdi:transmission-tower"
+        description: "S-phase apparent power"
+
+      - name: "Grid L2 Active Power"
+        l: 2
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: .1
+        rule: 2
+        registers: [42, 41]
+        icon: "mdi:transmission-tower"
+        description: "S-phase active power"
+
+      - name: "Grid L2 Reactive Power"
+        l: 2
+        class: "power"
+        state_class: "measurement"
+        uom: "var"
+        scale: .1
+        rule: 2
+        registers: [44, 43]
+        icon: "mdi:transmission-tower"
+        description: "S-phase reactive power"
+
+      - name: "Grid L3 Voltage"
+        l: 3
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [45]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid L3 Current"
+        l: 3
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: .1
+        rule: 2
+        registers: [46]
+        icon: "mdi:transmission-tower"
+
+      - name: "Grid L3 Apparent Power"
+        l: 3
+        class: "power"
+        state_class: "measurement"
+        uom: "VA"
+        scale: .1
+        rule: 2
+        registers: [48, 47]
+        icon: "mdi:transmission-tower"
+        description: "T-phase apparent power"
+
+      - name: "Grid L3 Active Power"
+        l: 3
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: .1
+        rule: 2
+        registers: [50, 49]
+        icon: "mdi:transmission-tower"
+        description: "T-phase active power"
+
+      - name: "Grid L3 Reactive Power"
+        l: 3
+        class: "power"
+        state_class: "measurement"
+        uom: "var"
+        scale: .1
+        rule: 2
+        registers: [52, 51]
+        icon: "mdi:transmission-tower"
+        description: "T-phase reactive power"
+
+      - name: "Grid Voltage RS"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [53]
+        icon: "mdi:transmission-tower"
+        description: "R-S line voltage"
+
+      - name: "Grid Voltage ST"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [54]
+        icon: "mdi:transmission-tower"
+        description: "S-T line voltage"
+
+      - name: "Grid Voltage TR"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [55]
+        icon: "mdi:transmission-tower"
+        description: "T-R line voltage"
+
+      - name: "CT1 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: .1
+        rule: 1
+        registers: [108]
+        description: "CT1 sampling current for external meter"
+
+      - name: "CT2 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: .1
+        rule: 1
+        registers: [109]
+        description: "CT2 sampling current for external meter"
+
+      - name: "CT Status"
+        class: "enum"
+        rule: 1
+        registers: [119]
+        description: "CT insertion detection status"
+        lookup:
+          - key: 0
+            value: "Not Inserted"
+          - key: 1
+            value: "Inserted"
+
   - group: Battery
     update_interval: 5
     items:
@@ -460,6 +687,94 @@ parameters:
             value: "No Fault"
           - key: default
             value: "Fault"
+
+      - name: "Software Sub Version"
+        rule: 1
+        registers: [121]
+        description: "DSP sub-version number"
+
+      - name: "MCU Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: .1
+        rule: 2
+        registers: [123]
+        description: "Monitor board chip temperature"
+
+      - name: "Ambient Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: .1
+        rule: 2
+        registers: [124]
+        description: "Monitor board environment temperature"
+
+      - name: "BatVolt DSP"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [129]
+        description: "Battery voltage sampled by the inverter"
+
+      - name: "LLC Voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [137]
+        description: "LLC resonant converter voltage"
+
+      - name: "BatPackVolt"
+        state_class: "measurement"
+        uom: "V"
+        scale: .1
+        rule: 1
+        registers: [138]
+        description: "Battery pack voltage"
+
+      - name: "Fault Subcode"
+        rule: 1
+        registers: [148]
+        description: "Inverter sub-fault code"
+
+      - name: "ISO Resistance"
+        state_class: "measurement"
+        uom: "k\u03A9"
+        rule: 1
+        registers: [318]
+        description: "Insulation resistance value"
+
+      - name: "GFCI"
+        state_class: "measurement"
+        uom: "mA"
+        rule: 2
+        registers: [319]
+        description: "Ground fault circuit interrupter current"
+
+      - name: "Derating Mode Flag"
+        class: "enum"
+        rule: 1
+        registers: [153]
+        description: "Derating mode indicator"
+        lookup:
+          - key: 0
+            value: "Normal"
+          - key: default
+            value: "Derating"
+
+      - name: "Power Cos Flag"
+        class: "enum"
+        rule: 1
+        registers: [154]
+        description: "Power factor leading/lagging indicator"
+        lookup:
+          - key: 0
+            value: "Lagging"
+          - key: 1
+            value: "Leading"
 
   - group: Energy
     update_interval: 30


### PR DESCRIPTION
This expands the Hinen H5000 profile with 18 new sensors covering AC metering, battery management, thermal monitoring, and firmware diagnostics.

Picks-up where I left from https://github.com/davidrapan/ha-solarman/discussions/198#discussioncomment-11634780

AC group:
- Grid Power (signed, registers [26,25]) - total AC active power
- Power Factor (register 57, with 10000 offset formula)
- AC Charge Power (registers [107,106]) - grid-to-battery AC charging

Battery group:
- Battery Combined Power (signed, registers [150,149]) - net battery power
- Battery Current (register 164) - BMS-measured battery current
- BMS Max Charge/Discharge Current (registers 166, 167)
- BMS Gauge Remaining and Full Charge Capacity (registers 168, 169)
- BMS Cycle Count (register 173)

Diagnostics group (new):
- IPM Temperature (register 133) - internal power module temperature
- LLC Temperature (register 134) - LLC resonant converter temperature
- Fan Speed (register 135)
- Bus1/Bus2 Voltage (registers 130, 131) - DC bus voltages
- Fault Maincode (register 147) - main fault code with lookup table

Info group:
- Master/Slave DSP Versions (registers 341, 342)

Also dixed a typo in the existing "Today Energy Export" sensor
(descripton -> description).

Tested on a Hinen H5000-EU Single-Phase Hybrid
(Model: S05U01T00E0FP0500B0500). All sensors reporting live data.

<img width="2328" height="1768" alt="image" src="https://github.com/user-attachments/assets/2e001571-a68f-4bde-9d7e-6f477c8f2816" />
<img width="333" height="774" alt="image" src="https://github.com/user-attachments/assets/87b48050-50c1-429b-b972-d1d9a321e6fa" />
<img width="331" height="769" alt="image" src="https://github.com/user-attachments/assets/4fe84197-fc6f-4d08-a720-b56939b255aa" />
<img width="347" height="645" alt="image" src="https://github.com/user-attachments/assets/178296ff-cc34-4a7a-9c12-3178dc6edbe7" />
