### PR TITLE
fix: Convert input registers 125/126 to read-only sensors | Hinen

### DIFF
--- a/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/hinen_hybrid.yaml
@@ -272,7 +272,6 @@ parameters:
     update_interval: 300
     items:
       - name: "Energy Pattern"
-        platform: "select"
         rule: 1
         registers: [125]
         icon: mdi:battery-sync
@@ -284,8 +283,7 @@ parameters:
           - key: 2
             value: "Grid"
             
-      - name: "Battery Control Mode"
-        platform: "select"
+      - name: "Battery Type"
         rule: 1
         registers: [126]
         icon: "mdi:battery"


### PR DESCRIPTION
## Summary

Fix two entities in the Hinen H5000 profile that were incorrectly declared as writable `select` platforms when their underlying Modbus registers are read-only input registers. Attempting to set a new value via these selects would silently write to the *holding* registers at the same address, which are different parameters entirely, and would potentially misconfigure the inverter.

## Changes

`custom_components/solarman/inverter_definitions/hinen_hybrid.yaml`

1. **Energy Pattern (reg 125)** — removed `platform: "select"`. This register is an input register reporting the current energy priority (Load/Battery/Grid). It has no writable counterpart — the holding register at address 125 is `BatteryType` (Lead-acid/Lithium/Others). Writing to it would change the battery chemistry setting, not the priority.

2. **Battery Control Mode (reg 126)** — removed `platform: "select"` and renamed to **Battery Type** to match the Modbus spec. Same issue: input register 126 reports the installed battery chemistry, but holding register 126 is `BatMdlSerialNum` (number of battery modules in series). Writing to it would change the module count.

This is the same pattern used by `kstar_hybrid.yaml` for its `Battery Type` entity.

## Testing

Verified in a local dev instance. Both `sensor.inverter_energy_pattern` and `sensor.inverter_battery_type` report correct values and are available on the API. Stale select entities from the entity registry were cleaned up after restart.

Before

(unavailable because I took the screenshot after I had already fixed the profile)

<img width="367" height="269" alt="image" src="https://github.com/user-attachments/assets/9353c76f-1a86-4d63-afea-e918e982de7e" />


After

<img width="352" height="66" alt="image" src="https://github.com/user-attachments/assets/0bc262d9-bcdc-4a6e-bdc2-24d15570eecf" />

<img width="356" height="63" alt="image" src="https://github.com/user-attachments/assets/585bd957-1a2f-4f94-b4cf-b3114f4d2c2f" />
