### PR TITLE
feat(deye_p3): add Signal Island Mode and Solar Arc Fault controls

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_p3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_p3.yaml
@@ -1369,6 +1369,18 @@ parameters:
         value:
           bit: 6
 
+      # LCD "Advanced Settings" -> "Signal Island Mode" checkbox.
+      # Bit 8 of 0x00B2 (doc: bit8-9 "external relay enable", bit9 stays the
+      # control bit, bit8 is the on/off flag). Verified on a live Sun-12K by
+      # toggling the LCD checkbox and diffing the raw register (0x2EAA<->0x2FAA).
+      - name: Signal Island Mode
+        platform: "switch"
+        rule: 1
+        registers: [0x00B2]
+        value:
+          bit: 8
+        icon: "mdi:island"
+
       - name: Off Grid
         platform: switch
         rule: 1
@@ -1376,6 +1388,24 @@ parameters:
           min: 0
           max: 1
         registers: [0x00B3]
+
+      # LCD "Advanced Settings" -> "Solar Arc Fault ON" / "Clear Arc Fault".
+      # Register 0x00B5 (doc reg 181): 0x01 = arc-fault detection on,
+      # 0x02 = clear/reset fault (auto-reverts to 0x01), 0 = off (observed).
+      # Verified on a live Sun-12K by diffing the raw register on LCD toggle.
+      - name: Solar Arc Fault
+        platform: switch
+        rule: 1
+        registers: [0x00B5]
+        icon: "mdi:flash-alert"
+
+      - name: Clear Arc Fault
+        platform: button
+        rule: 1
+        registers: [0x00B5]
+        value:
+          on: 2
+        icon: "mdi:flash-off"
 
       - name: Grid reconnection time
         platform: number


### PR DESCRIPTION
## What

Adds three "Advanced Settings" controls (visible on the inverter LCD) that
were missing from the Deye 3P profile:

| Control | Platform | Register | Notes |
|---|---|---|---|
| **Signal Island Mode** | switch | `0x00B2` bit 8 | doc: bit8-9 "external relay enable" |
| **Solar Arc Fault** | switch | `0x00B5` | doc reg 181: `0x01`=on, `0`=off |
| **Clear Arc Fault** | button | `0x00B5` ← `0x02` | resets fault, auto-reverts to `0x01` |

## How it was mapped

These LCD checkboxes are not named in the Modbus RTU doc (V105.2) in a way
that made the registers obvious, so each was identified empirically on a live
Sun-12K: temporary raw read-only sensors over the candidate register range,
then toggling the LCD checkbox and diffing.

- **Signal Island Mode** flips exactly bit 8 of `0x00B2`
  (`0x2EAA` ⇄ `0x2FAA`). Note `0x0053` "Island protection enable" is a
  *different* setting (constant `1`, does not track this checkbox), and
  `0x00B3` "Force off-grid" is the hard grid-relay cutoff — neither is this.
- **Solar Arc Fault ON** sets `0x00B5` to `1`; **Clear Arc Fault** writes `2`.

## Testing

Verified on a live Sun-12K (deye_p3 profile): each new entity reads back the
correct state after toggling the corresponding LCD checkbox; `python -m
py_compile` not needed (YAML only), `yaml.safe_load` of `deye_p3.yaml` passes.
